### PR TITLE
[Luna] Convert tests from paramsheet to profile-based configuration

### DIFF
--- a/conf/affy/affy.config
+++ b/conf/affy/affy.config
@@ -1,0 +1,41 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Affymetrix microarray analysis profile (default: Limma)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Sets parameters for Affymetrix array differential abundance analysis using Limma.
+    Use as follows:
+        nextflow run nf-core/differentialabundance -profile affy,<docker/singularity> --input <SAMPLESHEET> --affy_cel_files_archive <TAR> --outdir <OUTDIR>
+----------------------------------------------------------------------------------------
+*/
+
+params {
+    paramset_name                    = 'affy'
+
+    // Study
+    study_type                       = 'affy_array'
+    study_abundance_type             = 'intensities'
+
+    // Differential analysis (Limma)
+    differential_method              = 'limma'
+
+    // Features
+    features_id_col                  = 'PROBEID'
+    features_metadata_cols           = 'PROBEID,ENSEMBL,SYMBOL,GENETYPE'
+    features_name_col                = 'SYMBOL'
+    differential_feature_id_column   = 'PROBEID'
+    differential_feature_name_column = 'SYMBOL'
+
+    // Exploratory
+    exploratory_assay_names          = 'raw,normalised'
+    exploratory_final_assay          = 'normalised'
+    exploratory_log2_assays          = null
+
+    // Differential output columns
+    differential_file_suffix         = '.limma.results.tsv'
+    differential_fc_column           = 'logFC'
+    differential_pval_column         = 'P.Value'
+    differential_qval_column         = 'adj.P.Val'
+
+    // Shiny app
+    shinyngs_build_app               = true
+}

--- a/conf/affy/affy_limma_gprofiler2.config
+++ b/conf/affy/affy_limma_gprofiler2.config
@@ -1,0 +1,14 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Affymetrix Limma + g:Profiler2 analysis profile
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Inherits from affy.config and adds g:Profiler2 functional enrichment.
+----------------------------------------------------------------------------------------
+*/
+
+includeConfig 'affy.config'
+
+params {
+    paramset_name     = 'affy_limma_gprofiler2'
+    functional_method = 'gprofiler2'
+}

--- a/conf/affy/affy_limma_gsea.config
+++ b/conf/affy/affy_limma_gsea.config
@@ -1,0 +1,14 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Affymetrix Limma + GSEA analysis profile
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Inherits from affy.config and adds GSEA functional enrichment.
+----------------------------------------------------------------------------------------
+*/
+
+includeConfig 'affy.config'
+
+params {
+    paramset_name     = 'affy_limma_gsea'
+    functional_method = 'gsea'
+}

--- a/conf/maxquant/maxquant.config
+++ b/conf/maxquant/maxquant.config
@@ -1,0 +1,45 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    MaxQuant proteomics analysis profile (default: Limma)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Sets parameters for MaxQuant proteomics differential abundance analysis using Limma.
+    Use as follows:
+        nextflow run nf-core/differentialabundance -profile maxquant,<docker/singularity> --input <SAMPLESHEET> --matrix <MATRIX> --outdir <OUTDIR>
+----------------------------------------------------------------------------------------
+*/
+
+params {
+    paramset_name                    = 'maxquant'
+
+    // Study
+    study_type                       = 'maxquant'
+    study_abundance_type             = 'intensities'
+
+    // Differential analysis (Limma)
+    differential_method              = 'limma'
+
+    // Features
+    features_id_col                  = 'Majority protein IDs'
+    features_name_col                = 'Majority protein IDs'
+    features_metadata_cols           = 'Majority protein IDs'
+    features_type                    = 'protein'
+    differential_feature_id_column   = 'Majority protein IDs'
+    differential_feature_name_column = 'Majority protein IDs'
+
+    // Exploratory
+    exploratory_assay_names          = 'raw,normalised'
+    exploratory_final_assay          = 'normalised'
+    exploratory_log2_assays          = null
+
+    // Differential output columns
+    differential_file_suffix         = '.limma.results.tsv'
+    differential_fc_column           = 'logFC'
+    differential_pval_column         = 'P.Value'
+    differential_qval_column         = 'adj.P.Val'
+
+    // Proteus
+    proteus_measurecol_prefix        = 'LFQ intensity'
+
+    // Shiny app
+    shinyngs_build_app               = false
+}

--- a/conf/rnaseq/rnaseq.config
+++ b/conf/rnaseq/rnaseq.config
@@ -1,0 +1,43 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    RNA-seq analysis profile (default: DESeq2)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Sets parameters for RNA-seq differential abundance analysis using DESeq2.
+    Use as follows:
+        nextflow run nf-core/differentialabundance -profile rnaseq,<docker/singularity> --input <SAMPLESHEET> --matrix <MATRIX> --outdir <OUTDIR>
+----------------------------------------------------------------------------------------
+*/
+
+params {
+    paramset_name                    = 'rnaseq'
+
+    // Study
+    study_type                       = 'rnaseq'
+    study_abundance_type             = 'counts'
+
+    // Features
+    features_type                    = 'gene'
+    features_id_col                  = 'gene_id'
+    features_name_col                = 'gene_name'
+    features_metadata_cols           = 'gene_id,gene_name,gene_biotype'
+    differential_feature_id_column   = 'gene_id'
+    differential_feature_name_column = 'gene_name'
+
+    // Observations
+    observations_id_col              = 'sample'
+    observations_name_col            = 'sample'
+
+    // Differential analysis (DESeq2)
+    differential_method              = 'deseq2'
+
+    // Exploratory
+    exploratory_assay_names          = 'raw,normalised,variance_stabilised'
+    exploratory_final_assay          = 'variance_stabilised'
+    exploratory_log2_assays          = 'raw,normalised'
+
+    // Differential output columns
+    differential_file_suffix         = '.deseq2.results.tsv'
+    differential_fc_column           = 'log2FoldChange'
+    differential_pval_column         = 'pvalue'
+    differential_qval_column         = 'padj'
+}

--- a/conf/rnaseq/rnaseq_deseq2_gprofiler2.config
+++ b/conf/rnaseq/rnaseq_deseq2_gprofiler2.config
@@ -1,0 +1,14 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    RNA-seq DESeq2 + g:Profiler2 analysis profile
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Inherits from rnaseq.config (DESeq2) and adds g:Profiler2 functional enrichment.
+----------------------------------------------------------------------------------------
+*/
+
+includeConfig 'rnaseq.config'
+
+params {
+    paramset_name     = 'rnaseq_deseq2_gprofiler2'
+    functional_method = 'gprofiler2'
+}

--- a/conf/rnaseq/rnaseq_deseq2_gsea.config
+++ b/conf/rnaseq/rnaseq_deseq2_gsea.config
@@ -1,0 +1,14 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    RNA-seq DESeq2 + GSEA analysis profile
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Inherits from rnaseq.config (DESeq2) and adds GSEA functional enrichment.
+----------------------------------------------------------------------------------------
+*/
+
+includeConfig 'rnaseq.config'
+
+params {
+    paramset_name     = 'rnaseq_deseq2_gsea'
+    functional_method = 'gsea'
+}

--- a/conf/rnaseq/rnaseq_dream.config
+++ b/conf/rnaseq/rnaseq_dream.config
@@ -1,0 +1,29 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    RNA-seq DREAM analysis profile
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Inherits RNA-seq base settings from rnaseq.config and overrides with DREAM-specific
+    differential analysis parameters (mixed-effects models).
+----------------------------------------------------------------------------------------
+*/
+
+includeConfig 'rnaseq.config'
+
+params {
+    paramset_name            = 'rnaseq_dream'
+
+    // Differential analysis (DREAM)
+    differential_method      = 'dream'
+    dream_apply_voom         = true
+
+    // Exploratory
+    exploratory_assay_names  = 'raw,normalised'
+    exploratory_final_assay  = 'normalised'
+    exploratory_log2_assays  = 'raw'
+
+    // Differential output columns
+    differential_file_suffix = '.dream.results.tsv'
+    differential_fc_column   = 'logFC'
+    differential_pval_column = 'P.Value'
+    differential_qval_column = 'adj.P.Val'
+}

--- a/conf/rnaseq/rnaseq_dream_decoupler.config
+++ b/conf/rnaseq/rnaseq_dream_decoupler.config
@@ -1,0 +1,14 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    RNA-seq DREAM + Decoupler analysis profile
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Inherits from rnaseq_dream.config and adds Decoupler functional enrichment.
+----------------------------------------------------------------------------------------
+*/
+
+includeConfig 'rnaseq_dream.config'
+
+params {
+    paramset_name     = 'rnaseq_dream_decoupler'
+    functional_method = 'decoupler'
+}

--- a/conf/rnaseq/rnaseq_limma.config
+++ b/conf/rnaseq/rnaseq_limma.config
@@ -1,0 +1,29 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    RNA-seq Limma analysis profile
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Inherits RNA-seq base settings from rnaseq.config and overrides with Limma-specific
+    differential analysis parameters.
+----------------------------------------------------------------------------------------
+*/
+
+includeConfig 'rnaseq.config'
+
+params {
+    paramset_name            = 'rnaseq_limma'
+
+    // Differential analysis (Limma)
+    differential_method      = 'limma'
+    limma_use_voom           = true
+
+    // Exploratory
+    exploratory_assay_names  = 'raw,normalised'
+    exploratory_final_assay  = 'normalised'
+    exploratory_log2_assays  = 'raw'
+
+    // Differential output columns
+    differential_file_suffix = '.limma.results.tsv'
+    differential_fc_column   = 'logFC'
+    differential_pval_column = 'P.Value'
+    differential_qval_column = 'adj.P.Val'
+}

--- a/conf/rnaseq/rnaseq_limma_decoupler.config
+++ b/conf/rnaseq/rnaseq_limma_decoupler.config
@@ -1,0 +1,14 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    RNA-seq Limma + Decoupler analysis profile
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Inherits from rnaseq_limma.config and adds Decoupler functional enrichment.
+----------------------------------------------------------------------------------------
+*/
+
+includeConfig 'rnaseq_limma.config'
+
+params {
+    paramset_name     = 'rnaseq_limma_decoupler'
+    functional_method = 'decoupler'
+}

--- a/conf/rnaseq/rnaseq_limma_gprofiler2.config
+++ b/conf/rnaseq/rnaseq_limma_gprofiler2.config
@@ -1,0 +1,14 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    RNA-seq Limma + g:Profiler2 analysis profile
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Inherits from rnaseq_limma.config and adds g:Profiler2 functional enrichment.
+----------------------------------------------------------------------------------------
+*/
+
+includeConfig 'rnaseq_limma.config'
+
+params {
+    paramset_name     = 'rnaseq_limma_gprofiler2'
+    functional_method = 'gprofiler2'
+}

--- a/conf/rnaseq/rnaseq_limma_gsea.config
+++ b/conf/rnaseq/rnaseq_limma_gsea.config
@@ -1,0 +1,14 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    RNA-seq Limma + GSEA analysis profile
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Inherits from rnaseq_limma.config and adds GSEA functional enrichment.
+----------------------------------------------------------------------------------------
+*/
+
+includeConfig 'rnaseq_limma.config'
+
+params {
+    paramset_name     = 'rnaseq_limma_gsea'
+    functional_method = 'gsea'
+}

--- a/conf/rnaseq/rnaseq_nogtf.config
+++ b/conf/rnaseq/rnaseq_nogtf.config
@@ -1,0 +1,13 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    RNA-seq analysis profile without GTF annotation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Inherits from rnaseq.config (DESeq2). Use when no GTF annotation is available.
+----------------------------------------------------------------------------------------
+*/
+
+includeConfig 'rnaseq.config'
+
+params {
+    paramset_name = 'rnaseq_nogtf'
+}

--- a/conf/soft/soft.config
+++ b/conf/soft/soft.config
@@ -1,0 +1,42 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    GEO SOFT file analysis profile (default: Limma)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Sets parameters for GEO SOFT file differential abundance analysis using Limma.
+    Use as follows:
+        nextflow run nf-core/differentialabundance -profile soft,<docker/singularity> --input <SAMPLESHEET> --querygse <GSE_ID> --outdir <OUTDIR>
+----------------------------------------------------------------------------------------
+*/
+
+params {
+    paramset_name                    = 'soft'
+
+    // Study
+    study_type                       = 'geo_soft_file'
+    study_abundance_type             = 'intensities'
+
+    // Differential analysis (Limma)
+    differential_method              = 'limma'
+
+    // Observations
+    observations_id_col              = 'id'
+    observations_name_col            = 'id'
+
+    // Features
+    features_id_col                  = 'ID'
+    features_metadata_cols           = 'ID,ENTREZ_GENE_ID,Gene Symbol,Sequence Type'
+    features_name_col                = 'Gene Symbol'
+    differential_feature_id_column   = 'ID'
+    differential_feature_name_column = 'Symbol'
+
+    // Exploratory
+    exploratory_assay_names          = 'normalised'
+    exploratory_final_assay          = 'normalised'
+    exploratory_log2_assays          = null
+
+    // Differential output columns
+    differential_file_suffix         = '.limma.results.tsv'
+    differential_fc_column           = 'logFC'
+    differential_pval_column         = 'P.Value'
+    differential_qval_column         = 'adj.P.Val'
+}

--- a/conf/test.config
+++ b/conf/test.config
@@ -10,9 +10,9 @@
 ----------------------------------------------------------------------------------------
 */
 
-params {
-    paramset_name = "deseq2_rnaseq_gsea"
+includeConfig 'rnaseq/rnaseq_deseq2_gsea.config'
 
+params {
     study_name                 = 'SRP254919'
     config_profile_name        = 'Test profile'
     config_profile_description = 'Minimal test dataset to check pipeline function'

--- a/nextflow.config
+++ b/nextflow.config
@@ -29,7 +29,7 @@ params {
 
     // Paramsheet options
     paramset_name              = null
-    paramsheet                 = "${projectDir}/conf/paramsheet.yaml"
+    paramsheet                 = null
 
     // Sample sheet options
     observations_type          = 'sample'
@@ -371,6 +371,24 @@ profiles {
         singularity.runOptions  = '--nv'
     }
 
+    // Analysis profiles (single-run mode)
+    rnaseq                    { includeConfig 'conf/rnaseq/rnaseq.config'                    }
+    rnaseq_nogtf              { includeConfig 'conf/rnaseq/rnaseq_nogtf.config'              }
+    rnaseq_deseq2_gsea        { includeConfig 'conf/rnaseq/rnaseq_deseq2_gsea.config'        }
+    rnaseq_deseq2_gprofiler2  { includeConfig 'conf/rnaseq/rnaseq_deseq2_gprofiler2.config'  }
+    rnaseq_limma              { includeConfig 'conf/rnaseq/rnaseq_limma.config'              }
+    rnaseq_limma_gsea         { includeConfig 'conf/rnaseq/rnaseq_limma_gsea.config'         }
+    rnaseq_limma_gprofiler2   { includeConfig 'conf/rnaseq/rnaseq_limma_gprofiler2.config'   }
+    rnaseq_limma_decoupler    { includeConfig 'conf/rnaseq/rnaseq_limma_decoupler.config'    }
+    rnaseq_dream              { includeConfig 'conf/rnaseq/rnaseq_dream.config'              }
+    rnaseq_dream_decoupler    { includeConfig 'conf/rnaseq/rnaseq_dream_decoupler.config'    }
+    affy                      { includeConfig 'conf/affy/affy.config'                        }
+    affy_limma_gsea           { includeConfig 'conf/affy/affy_limma_gsea.config'             }
+    affy_limma_gprofiler2     { includeConfig 'conf/affy/affy_limma_gprofiler2.config'       }
+    maxquant                  { includeConfig 'conf/maxquant/maxquant.config'                }
+    soft                      { includeConfig 'conf/soft/soft.config'                        }
+
+    // Test profiles
     test              { includeConfig 'conf/test.config'              }
     test_full         { includeConfig 'conf/test_full.config'         }
     cache_default     { includeConfig 'conf/cache_default.config'     }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -206,12 +206,12 @@
             "properties": {
                 "paramset_name": {
                     "type": "string",
-                    "description": "Name of the paramset (as specified in assets/paramsheet) to run specific analyses"
+                    "description": "Name of the paramset to run. In profile mode, set by the analysis profile for output directory naming. In paramsheet mode, selects which paramset(s) to run (comma-separated)."
                 },
                 "paramsheet": {
                     "type": "string",
-                    "description": "Path to a paramsheet file",
-                    "help_text": "A YAML file that defines 1+ nextflow config(s).",
+                    "description": "Path to a paramsheet YAML file. Setting this activates multi-run (paramsheet) mode where paramsheet values take priority over CLI flags.",
+                    "help_text": "A YAML file that defines 1+ nextflow config(s). When not set, the pipeline uses standard Nextflow config profiles (single-run mode) where CLI flags have highest priority.",
                     "pattern": "^\\S+\\.(yaml|yml)$",
                     "format": "file-path",
                     "mimetype": "text/csv"

--- a/subworkflows/local/utils_nfcore_differentialabundance_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_differentialabundance_pipeline/main.nf
@@ -340,8 +340,8 @@ def methodsDescriptionText(mqc_methods_yaml) {
 // Get configurations based on whether use paramsheet or default params
 // and validate them against the schema.
 def getParamsetConfigurations() {
-    // Use paramsheet if paramset_name is provided, otherwise use default params
-    def paramsets = (params.paramset_name) ? getParamsheetConfigurations() : getDefaultConfigurations()
+    // Use paramsheet if --paramsheet is explicitly provided, otherwise use default params (profile mode)
+    def paramsets = (params.paramsheet) ? getParamsheetConfigurations() : getDefaultConfigurations()
 
     return paramsets.collect { paramset ->
         // Some params are not useful through the pipeline run.
@@ -379,7 +379,7 @@ def getParamsheetConfigurations() {
 
     def paramsheet = raw_paramsheet
         .findAll { row ->
-            if (params.paramset_name == 'all') {
+            if (!params.paramset_name || params.paramset_name == 'all') {
                 return true
             } else {
                 // Only keep row matching with paramset name(s)
@@ -404,10 +404,11 @@ def getParamsheetConfigurations() {
         }
 }
 
-// Get default configurations from pipeline parameters
+// Get default configurations from pipeline parameters (profile mode)
 def getDefaultConfigurations() {
-    // replace null by string 'contrasts' for paramset_name to avoid certain problems with null object
-    return [params + [paramset_name: 'contrasts']]
+    // Use paramset_name from profile if set, otherwise fall back to 'contrasts'
+    def pname = params.paramset_name ?: 'contrasts'
+    return [params + [paramset_name: pname]]
 }
 
 // Load configurations from yaml file

--- a/tests/default.nf.test
+++ b/tests/default.nf.test
@@ -71,10 +71,41 @@ nextflow_pipeline {
 
         when {
             params {
-                outdir        = "$outputDir"
-                paramsheet    = "${projectDir}/conf/test_paramsheet.yaml"
-                paramset_name = "deseq2_rnaseq_gprofiler2_complex"
+                outdir                     = "$outputDir"
+
+                // Study info
+                study_name                 = 'SRP254919'
+
+                // Input data (complex dataset)
+                input                      = 'https://github.com/nf-core/test-datasets/raw/differentialabundance/modules_testdata/variancepartition_dream/metadata.tsv'
+                matrix                     = 'https://github.com/nf-core/test-datasets/raw/differentialabundance/modules_testdata/variancepartition_dream/counts.tsv'
+                contrasts_yml              = 'https://github.com/nf-core/test-datasets/raw/differentialabundance/testdata/formula_contrasts/rnaseq_complex_contrast.yaml'
+                gtf                        = 'https://ftp.ensembl.org/pub/release-81/gtf/mus_musculus/Mus_musculus.GRCm38.81.gtf.gz'
+
+                // Exploratory plots
+                exploratory_main_variable  = 'contrasts'
+                exploratory_log2_assays    = 'raw'
+
+                // DESeq2
+                deseq2_vst_nsub            = 500
+                deseq2_seed                = 1
+                deseq2_vs_method           = 'rlog'
+                deseq2_shrink_lfc          = false
+
+                // gprofiler2 options
+                gprofiler2_organism        = 'mmusculus'
+
+                // Filtering
+                filtering_min_abundance    = 10
+
+                // Report options
+                report_contributors        = 'Jane Doe\nDirector of Institute of Microbiology\nUniversity of Smallville;John Smith\nPhD student\nInstitute of Microbiology\nUniversity of Smallville'
+
+                // Other
+                round_digits               = 2
+                skip_reports               = true
             }
+            profile 'rnaseq_deseq2_gprofiler2'
         }
 
         then {

--- a/tests/test_affy.nf.test
+++ b/tests/test_affy.nf.test
@@ -5,15 +5,37 @@ nextflow_pipeline {
     tag "affy"
     tag "pipeline"
 
-    test("Test affy profile - limma_affy_gsea") {
-
+    test("Test affy profile - affy_limma_gsea") {
 
         when {
             params {
-                outdir              = "$outputDir"
-                paramsheet          = "${projectDir}/conf/test_paramsheet.yaml"
-                paramset_name       = "limma_affy_gsea"
+                outdir                     = "$outputDir"
+
+                // Study info
+                study_name                 = 'GSE50790'
+
+                // Input data
+                input                      = 'https://raw.githubusercontent.com/nf-core/test-datasets/differentialabundance/testdata/GSE50790.csv'
+                contrasts_yml              = 'https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/differentialabundance/testdata/GSE50790_contrasts.yaml'
+                affy_cel_files_archive     = 'https://raw.githubusercontent.com/nf-core/test-datasets/differentialabundance/testdata/GSE50790_RAW.tar'
+                gene_sets_files            = 'https://raw.githubusercontent.com/nf-core/test-datasets/differentialabundance/testdata/h.all.v2022.1.Hs.symbols.gmt'
+
+                // Observations
+                observations_id_col        = 'name'
+                observations_name_col      = 'name'
+
+                // Exploratory
+                exploratory_main_variable  = 'contrasts'
+
+                // Differential analysis params
+                differential_max_pval      = 0.05
+                differential_max_qval      = 0.05
+                differential_min_fold_change = 1.5
+
+                // GSEA
+                gsea_rnd_seed              = '10'
             }
+            profile 'affy_limma_gsea'
         }
 
         then {
@@ -39,14 +61,36 @@ nextflow_pipeline {
         }
     }
 
-    test("Test affy profile - limma_affy_gsea,limma_affy_gprofiler2") {
+    test("Test affy profile - affy_limma_gprofiler2") {
 
         when {
             params {
-                outdir              = "$outputDir"
-                paramsheet          = "${projectDir}/conf/test_paramsheet.yaml"
-                paramset_name       = "limma_affy_gsea,limma_affy_gprofiler2"
+                outdir                     = "$outputDir"
+
+                // Study info
+                study_name                 = 'GSE50790'
+
+                // Input data
+                input                      = 'https://raw.githubusercontent.com/nf-core/test-datasets/differentialabundance/testdata/GSE50790.csv'
+                contrasts_yml              = 'https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/differentialabundance/testdata/GSE50790_contrasts.yaml'
+                affy_cel_files_archive     = 'https://raw.githubusercontent.com/nf-core/test-datasets/differentialabundance/testdata/GSE50790_RAW.tar'
+
+                // Observations
+                observations_id_col        = 'name'
+                observations_name_col      = 'name'
+
+                // Exploratory
+                exploratory_main_variable  = 'contrasts'
+
+                // Differential analysis params
+                differential_max_pval      = 0.05
+                differential_max_qval      = 0.05
+                differential_min_fold_change = 1.5
+
+                // gprofiler2 options
+                gprofiler2_organism        = 'mmusculus'
             }
+            profile 'affy_limma_gprofiler2'
         }
 
         then {

--- a/tests/test_maxquant.nf.test
+++ b/tests/test_maxquant.nf.test
@@ -6,15 +6,29 @@ nextflow_pipeline {
     tag "pipeline"
 
 
-    test("Test maxquant profile - limma_maxquant") {
+    test("Test maxquant profile - maxquant") {
 
         when {
             params {
-                outdir              = "$outputDir"
-                paramsheet          = "${projectDir}/conf/test_paramsheet.yaml"
-                paramset_name       = "limma_maxquant"
-            }
+                outdir                     = "$outputDir"
 
+                // Study info
+                study_name                 = 'PXD043349'
+
+                // Input data
+                input                      = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/proteomics/maxquant/MaxQuant_samplesheet.tsv'
+                matrix                     = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/proteomics/maxquant/MaxQuant_proteinGroups.txt'
+                contrasts_yml              = 'https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/differentialabundance/testdata/MaxQuant_contrasts.yaml'
+
+                // Observations
+                observations_id_col        = 'Experiment'
+                observations_name_col      = 'Name'
+
+                // Exploratory
+                exploratory_main_variable  = 'Celltype'
+                exploratory_n_features     = -1
+            }
+            profile 'maxquant'
         }
 
         then {

--- a/tests/test_nogtf.nf.test
+++ b/tests/test_nogtf.nf.test
@@ -9,10 +9,24 @@ nextflow_pipeline {
 
         when {
             params {
-                outdir              = "$outputDir"
-                paramsheet          = "${projectDir}/conf/test_paramsheet.yaml"
-                paramset_name       = "rnaseq_nogtf"
+                outdir                     = "$outputDir"
+
+                // Study info
+                study_name                 = 'SRP254919'
+
+                // Input data
+                input                      = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.samplesheet.csv'
+                matrix                     = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.salmon.merged.gene_counts.top1000cov.tsv'
+                contrasts_yml              = 'https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/differentialabundance/testdata/SRP254919.contrasts.yaml'
+
+                // Exploratory plots
+                exploratory_main_variable  = 'contrasts'
+                deseq2_vst_nsub            = 500
+
+                // Filtering
+                filtering_min_abundance    = 10
             }
+            profile 'rnaseq_nogtf'
         }
 
         then {

--- a/tests/test_rnaseq_deseq2.nf.test
+++ b/tests/test_rnaseq_deseq2.nf.test
@@ -5,14 +5,38 @@ nextflow_pipeline {
     tag "test_rnaseq_deseq2"
     tag "pipeline"
 
-    test("Test profile - deseq2_rnaseq_gsea") {
+    test("Test profile - rnaseq_deseq2_gsea") {
 
         when {
             params {
-                outdir        = "$outputDir"
-                paramsheet    = "${projectDir}/conf/test_paramsheet.yaml"
-                paramset_name = "deseq2_rnaseq_gsea"
+                outdir                     = "$outputDir"
+
+                // Study info
+                study_name                 = 'SRP254919'
+
+                // Input data
+                input                      = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.samplesheet.csv'
+                matrix                     = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.salmon.merged.gene_counts.top1000cov.tsv'
+                transcript_length_matrix   = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.spoofed_lengths.tsv'
+                contrasts_yml              = 'https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/differentialabundance/testdata/SRP254919.contrasts.yaml'
+                gtf                        = 'https://ftp.ensembl.org/pub/release-81/gtf/mus_musculus/Mus_musculus.GRCm38.81.gtf.gz'
+                gene_sets_files            = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/gene_set_analysis/mh.all.v2022.1.Mm.symbols.gmt'
+
+                // Exploratory plots
+                exploratory_main_variable  = 'contrasts'
+                deseq2_vst_nsub            = 500
+
+                // Filtering
+                filtering_min_abundance    = 10
+
+                // Report options
+                report_contributors        = 'Jane Doe\nDirector of Institute of Microbiology\nUniversity of Smallville;John Smith\nPhD student\nInstitute of Microbiology\nUniversity of Smallville'
+
+                // Other
+                round_digits               = 3
+                gsea_rnd_seed              = '10'
             }
+            profile 'rnaseq_deseq2_gsea'
         }
 
         then {
@@ -36,14 +60,39 @@ nextflow_pipeline {
         }
     }
 
-    test("Test profile - deseq2_rnaseq_gsea,deseq2_rnaseq_gprofiler2") {
+    test("Test profile - rnaseq_deseq2_gprofiler2") {
 
         when {
             params {
-                outdir        = "$outputDir"
-                paramsheet    = "${projectDir}/conf/test_paramsheet.yaml"
-                paramset_name = "deseq2_rnaseq_gsea,deseq2_rnaseq_gprofiler2"
+                outdir                     = "$outputDir"
+
+                // Study info
+                study_name                 = 'SRP254919'
+
+                // Input data
+                input                      = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.samplesheet.csv'
+                matrix                     = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.salmon.merged.gene_counts.top1000cov.tsv'
+                transcript_length_matrix   = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.spoofed_lengths.tsv'
+                contrasts_yml              = 'https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/differentialabundance/testdata/SRP254919.contrasts.yaml'
+                gtf                        = 'https://ftp.ensembl.org/pub/release-81/gtf/mus_musculus/Mus_musculus.GRCm38.81.gtf.gz'
+
+                // Exploratory plots
+                exploratory_main_variable  = 'contrasts'
+                deseq2_vst_nsub            = 500
+
+                // Filtering
+                filtering_min_abundance    = 10
+
+                // gprofiler2 options
+                gprofiler2_organism        = 'mmusculus'
+
+                // Report options
+                report_contributors        = 'Jane Doe\nDirector of Institute of Microbiology\nUniversity of Smallville;John Smith\nPhD student\nInstitute of Microbiology\nUniversity of Smallville'
+
+                // Other
+                round_digits               = 3
             }
+            profile 'rnaseq_deseq2_gprofiler2'
         }
 
         then {
@@ -67,13 +116,92 @@ nextflow_pipeline {
         }
     }
 
-    test("Test - Numeric sample IDs") {
+    test("Test - Numeric sample IDs - rnaseq_deseq2_gsea") {
         when {
             params {
-                outdir        = "$outputDir"
-                paramsheet    = "${projectDir}/conf/test_paramsheet.yaml"
-                paramset_name = "deseq2_rnaseq_gsea_numeric_samples,deseq2_rnaseq_gprofiler2_numeric_samples"
+                outdir                     = "$outputDir"
+
+                // Study info
+                study_name                 = 'SRP254919'
+
+                // Input data (local files with numeric sample IDs)
+                input                      = '${projectDir}/tests/assets/SRP254919.samplesheet.csv'
+                matrix                     = '${projectDir}/tests/assets/SRP254919.salmon.merged.gene_counts.top1000cov.tsv'
+                transcript_length_matrix   = '${projectDir}/tests/assets/SRP254919.spoofed_lengths.tsv'
+                contrasts_yml              = 'https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/differentialabundance/testdata/SRP254919.contrasts.yaml'
+                gtf                        = 'https://ftp.ensembl.org/pub/release-81/gtf/mus_musculus/Mus_musculus.GRCm38.81.gtf.gz'
+                gene_sets_files            = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/gene_set_analysis/mh.all.v2022.1.Mm.symbols.gmt'
+
+                // Exploratory plots
+                exploratory_main_variable  = 'contrasts'
+                deseq2_vst_nsub            = 500
+
+                // Filtering
+                filtering_min_abundance    = 10
+
+                // Report options
+                report_contributors        = 'Jane Doe\nDirector of Institute of Microbiology\nUniversity of Smallville;John Smith\nPhD student\nInstitute of Microbiology\nUniversity of Smallville'
+
+                // Other
+                round_digits               = 3
+                gsea_rnd_seed              = '10'
             }
+            profile 'rnaseq_deseq2_gsea'
+        }
+
+        then {
+            // stable_name: All files + folders in ${params.outdir}/ with a stable name
+            def stable_name = getAllFilesFromDir(params.outdir, relative: true, includeDir: true, ignore: ['pipeline_info/*.{html,json,txt}'])
+            // stable_path: All files in ${params.outdir}/ with stable content
+            def stable_path = getAllFilesFromDir(params.outdir, ignoreFile: 'tests/.nftignore')
+            assertAll(
+                { assert workflow.success},
+                { assert snapshot(
+                    // Number of successful tasks
+                    workflow.trace.succeeded().size(),
+                    // pipeline versions.yml file for multiqc from which Nextflow version is removed because we tests pipelines on multiple Nextflow versions
+                    removeNextflowVersion("$outputDir/pipeline_info/nf_core_differentialabundance_software_versions.yml"),
+                    // All stable path name, with a relative path
+                    stable_name,
+                    // All files with stable contents
+                    stable_path
+                ).match() }
+                )
+        }
+    }
+
+    test("Test - Numeric sample IDs - rnaseq_deseq2_gprofiler2") {
+        when {
+            params {
+                outdir                     = "$outputDir"
+
+                // Study info
+                study_name                 = 'SRP254919'
+
+                // Input data (local files with numeric sample IDs)
+                input                      = '${projectDir}/tests/assets/SRP254919.samplesheet.csv'
+                matrix                     = '${projectDir}/tests/assets/SRP254919.salmon.merged.gene_counts.top1000cov.tsv'
+                transcript_length_matrix   = '${projectDir}/tests/assets/SRP254919.spoofed_lengths.tsv'
+                contrasts_yml              = 'https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/differentialabundance/testdata/SRP254919.contrasts.yaml'
+                gtf                        = 'https://ftp.ensembl.org/pub/release-81/gtf/mus_musculus/Mus_musculus.GRCm38.81.gtf.gz'
+
+                // Exploratory plots
+                exploratory_main_variable  = 'contrasts'
+                deseq2_vst_nsub            = 500
+
+                // Filtering
+                filtering_min_abundance    = 10
+
+                // gprofiler2 options
+                gprofiler2_organism        = 'mmusculus'
+
+                // Report options
+                report_contributors        = 'Jane Doe\nDirector of Institute of Microbiology\nUniversity of Smallville;John Smith\nPhD student\nInstitute of Microbiology\nUniversity of Smallville'
+
+                // Other
+                round_digits               = 3
+            }
+            profile 'rnaseq_deseq2_gprofiler2'
         }
 
         then {

--- a/tests/test_rnaseq_dream.nf.test
+++ b/tests/test_rnaseq_dream.nf.test
@@ -5,14 +5,37 @@ nextflow_pipeline {
     tag "rnaseq_dream"
     tag "pipeline"
 
-    test("Test rnaseq dream profile - dream_rnaseq") {
+    test("Test rnaseq dream profile - rnaseq_dream") {
 
         when {
             params {
-                outdir              = "$outputDir"
-                paramsheet          = "${projectDir}/conf/test_paramsheet.yaml"
-                paramset_name       = "dream_rnaseq"
+                outdir                     = "$outputDir"
+
+                // Study info
+                study_name                 = 'SRP254919'
+
+                // Input data (complex dataset)
+                input                      = 'https://github.com/nf-core/test-datasets/raw/differentialabundance/modules_testdata/variancepartition_dream/metadata.tsv'
+                matrix                     = 'https://github.com/nf-core/test-datasets/raw/differentialabundance/modules_testdata/variancepartition_dream/counts.tsv'
+                contrasts_yml              = 'https://github.com/nf-core/test-datasets/raw/differentialabundance/testdata/formula_contrasts/rnaseq_complex_contrast.yaml'
+                gtf                        = 'https://ftp.ensembl.org/pub/release-81/gtf/mus_musculus/Mus_musculus.GRCm38.81.gtf.gz'
+
+                // DREAM settings
+                dream_apply_voom           = true
+
+                // Filtering
+                filtering_min_abundance    = 10
+
+                // Exploratory
+                exploratory_main_variable  = 'contrasts'
+
+                // Report options
+                report_contributors        = 'Jane Doe\nDirector of Institute of Microbiology\nUniversity of Smallville;John Smith\nPhD student\nInstitute of Microbiology\nUniversity of Smallville'
+
+                // Other
+                round_digits               = 3
             }
+            profile 'rnaseq_dream'
         }
 
         then {
@@ -39,10 +62,38 @@ nextflow_pipeline {
     test("Test rnaseq dream profile - complex contrast - with zero intercept") {
         when {
             params {
-                outdir              = "$outputDir"
-                paramsheet          = "${projectDir}/conf/test_paramsheet.yaml"
-                paramset_name       = "dream_norm"
+                outdir                     = "$outputDir"
+
+                // Study info
+                study_name                 = 'SRP254919'
+
+                // Input data (complex dataset with zero intercept contrasts)
+                input                      = 'https://github.com/nf-core/test-datasets/raw/differentialabundance/modules_testdata/variancepartition_dream/metadata.tsv'
+                matrix                     = 'https://github.com/nf-core/test-datasets/raw/differentialabundance/modules_testdata/variancepartition_dream/counts.tsv'
+                contrasts_yml              = '${projectDir}/tests/assets/zero_intercept_contrasts.yml'
+                gtf                        = 'https://ftp.ensembl.org/pub/release-81/gtf/mus_musculus/Mus_musculus.GRCm38.81.gtf.gz'
+
+                // DREAM settings - override for dream_norm
+                dream_apply_voom           = false
+
+                // Exploratory settings for dream_norm (no voom)
+                exploratory_assay_names    = 'raw'
+                exploratory_final_assay    = 'raw'
+                exploratory_log2_assays    = 'raw'
+
+                // Filtering
+                filtering_min_abundance    = 10
+
+                // Exploratory
+                exploratory_main_variable  = 'contrasts'
+
+                // Report options
+                report_contributors        = 'Jane Doe\nDirector of Institute of Microbiology\nUniversity of Smallville;John Smith\nPhD student\nInstitute of Microbiology\nUniversity of Smallville'
+
+                // Other
+                round_digits               = 3
             }
+            profile 'rnaseq_dream'
         }
 
         then {
@@ -66,14 +117,35 @@ nextflow_pipeline {
         }
     }
 
-    test("Test rnaseq dream profile - with decoupler") {
+    test("Test rnaseq dream profile - rnaseq_dream_decoupler") {
 
         when {
             params {
-                outdir              = "$outputDir"
-                paramsheet          = "${projectDir}/conf/test_paramsheet.yaml"
-                paramset_name       = "dream_rnaseq_decoupler"
+                outdir                     = "$outputDir"
+
+                // Study info
+                study_name                 = 'SRP254919'
+
+                // Input data (complex dataset)
+                input                      = 'https://github.com/nf-core/test-datasets/raw/differentialabundance/modules_testdata/variancepartition_dream/metadata.tsv'
+                matrix                     = 'https://github.com/nf-core/test-datasets/raw/differentialabundance/modules_testdata/variancepartition_dream/counts.tsv'
+                contrasts_yml              = 'https://github.com/nf-core/test-datasets/raw/differentialabundance/testdata/formula_contrasts/rnaseq_complex_contrast.yaml'
+                gtf                        = 'https://ftp.ensembl.org/pub/release-81/gtf/mus_musculus/Mus_musculus.GRCm38.81.gtf.gz'
+                decoupler_network          = 'https://github.com/nf-core/test-datasets/raw/differentialabundance/modules_testdata/progeny/mouse_network.tsv'
+
+                // Filtering
+                filtering_min_abundance    = 10
+
+                // Functional analysis with decoupler
+                decoupler_min_n            = 1
+
+                // Report options
+                report_contributors        = 'Jane Doe\nDirector of Institute of Microbiology\nUniversity of Smallville;John Smith\nPhD student\nInstitute of Microbiology\nUniversity of Smallville'
+
+                // Other
+                round_digits               = 3
             }
+            profile 'rnaseq_dream_decoupler'
         }
 
         then {
@@ -97,13 +169,34 @@ nextflow_pipeline {
         }
     }
 
-    test("Test - Numeric sample IDs - rnaseq dream profile - with decoupler") {
+    test("Test - Numeric sample IDs - rnaseq_dream_decoupler") {
         when {
             params {
-                outdir              = "$outputDir"
-                paramsheet          = "${projectDir}/conf/test_paramsheet.yaml"
-                paramset_name       = "dream_rnaseq_decoupler_numeric_samples"
+                outdir                     = "$outputDir"
+
+                // Study info
+                study_name                 = 'SRP254919'
+
+                // Input data (local files with numeric sample IDs)
+                input                      = '${projectDir}/tests/assets/SRP254919.samplesheet.csv'
+                matrix                     = '${projectDir}/tests/assets/SRP254919.salmon.merged.gene_counts.top1000cov.tsv'
+                contrasts_yml              = '${projectDir}/tests/assets/SRP254919_dream.contrasts.yaml'
+                gtf                        = 'https://ftp.ensembl.org/pub/release-81/gtf/mus_musculus/Mus_musculus.GRCm38.81.gtf.gz'
+                decoupler_network          = 'https://github.com/nf-core/test-datasets/raw/differentialabundance/modules_testdata/progeny/mouse_network.tsv'
+
+                // Filtering
+                filtering_min_abundance    = 10
+
+                // Functional analysis with decoupler
+                decoupler_min_n            = 1
+
+                // Report options
+                report_contributors        = 'Jane Doe\nDirector of Institute of Microbiology\nUniversity of Smallville;John Smith\nPhD student\nInstitute of Microbiology\nUniversity of Smallville'
+
+                // Other
+                round_digits               = 3
             }
+            profile 'rnaseq_dream_decoupler'
         }
 
         then {

--- a/tests/test_rnaseq_limma.nf.test
+++ b/tests/test_rnaseq_limma.nf.test
@@ -5,14 +5,39 @@ nextflow_pipeline {
     tag "rnaseq_limma"
     tag "pipeline"
 
-    test("Test rnaseq limma profile - limma_rnaseq_gsea") {
+    test("Test rnaseq limma profile - rnaseq_limma_gsea") {
 
         when {
             params {
-                outdir        = "$outputDir"
-                paramsheet    = "${projectDir}/conf/test_paramsheet.yaml"
-                paramset_name = "limma_rnaseq_gsea"
+                outdir                     = "$outputDir"
+
+                // Study info
+                study_name                 = 'SRP254919'
+
+                // Input data
+                input                      = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.samplesheet.csv'
+                matrix                     = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.salmon.merged.gene_counts.top1000cov.tsv'
+                transcript_length_matrix   = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.spoofed_lengths.tsv'
+                contrasts_yml              = 'https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/differentialabundance/testdata/SRP254919.contrasts.yaml'
+                gtf                        = 'https://ftp.ensembl.org/pub/release-81/gtf/mus_musculus/Mus_musculus.GRCm38.81.gtf.gz'
+                gene_sets_files            = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/gene_set_analysis/mh.all.v2022.1.Mm.symbols.gmt'
+
+                // Filtering
+                filtering_min_abundance    = 10
+
+                // Exploratory
+                exploratory_main_variable  = 'contrasts'
+
+                // GSEA
+                gsea_rnd_seed              = '10'
+
+                // Report options
+                report_contributors        = 'Jane Doe\nDirector of Institute of Microbiology\nUniversity of Smallville;John Smith\nPhD student\nInstitute of Microbiology\nUniversity of Smallville'
+
+                // Other
+                round_digits               = 3
             }
+            profile 'rnaseq_limma_gsea'
         }
 
         then {
@@ -36,14 +61,35 @@ nextflow_pipeline {
         }
     }
 
-    test("Test rnaseq limma profile - limma_rnaseq_gsea,limma_rnaseq_gprofiler2") {
+    test("Test rnaseq limma profile - rnaseq_limma_gprofiler2") {
 
         when {
             params {
-                outdir        = "$outputDir"
-                paramsheet    = "${projectDir}/conf/test_paramsheet.yaml"
-                paramset_name = "limma_rnaseq_gsea,limma_rnaseq_gprofiler2"
+                outdir                     = "$outputDir"
+
+                // Study info
+                study_name                 = 'SRP254919'
+
+                // Input data
+                input                      = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.samplesheet.csv'
+                matrix                     = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.salmon.merged.gene_counts.top1000cov.tsv'
+                transcript_length_matrix   = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.spoofed_lengths.tsv'
+                contrasts_yml              = 'https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/differentialabundance/testdata/SRP254919.contrasts.yaml'
+                gtf                        = 'https://ftp.ensembl.org/pub/release-81/gtf/mus_musculus/Mus_musculus.GRCm38.81.gtf.gz'
+
+                // Filtering
+                filtering_min_abundance    = 10
+
+                // gprofiler2 options
+                gprofiler2_organism        = 'mmusculus'
+
+                // Report options
+                report_contributors        = 'Jane Doe\nDirector of Institute of Microbiology\nUniversity of Smallville;John Smith\nPhD student\nInstitute of Microbiology\nUniversity of Smallville'
+
+                // Other
+                round_digits               = 3
             }
+            profile 'rnaseq_limma_gprofiler2'
         }
 
         then {
@@ -67,15 +113,41 @@ nextflow_pipeline {
         }
     }
 
-    test("Test rnaseq limma profile - limma_rnaseq_gsea - with formula and complex contrasts") {
+    test("Test rnaseq limma profile - rnaseq_limma_gsea - with formula and complex contrasts") {
         tag "limma_rnaseq_gsea_complex"
 
         when {
             params {
-                outdir        = "$outputDir"
-                paramsheet    = "${projectDir}/conf/test_paramsheet.yaml"
-                paramset_name = "limma_rnaseq_gsea_complex"
+                outdir                     = "$outputDir"
+
+                // Study info
+                study_name                 = 'SRP254919'
+
+                // Input data (complex dataset)
+                input                      = 'https://github.com/nf-core/test-datasets/raw/differentialabundance/modules_testdata/variancepartition_dream/metadata.tsv'
+                matrix                     = 'https://github.com/nf-core/test-datasets/raw/differentialabundance/modules_testdata/variancepartition_dream/counts.tsv'
+                contrasts_yml              = 'https://github.com/nf-core/test-datasets/raw/differentialabundance/testdata/formula_contrasts/rnaseq_complex_contrast.yaml'
+                gtf                        = 'https://ftp.ensembl.org/pub/release-81/gtf/mus_musculus/Mus_musculus.GRCm38.81.gtf.gz'
+                gene_sets_files            = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/gene_set_analysis/mh.all.v2022.1.Mm.symbols.gmt'
+
+                // Filtering
+                filtering_min_abundance    = 10
+
+                // Exploratory
+                exploratory_main_variable  = 'contrasts'
+                exploratory_log2_assays    = 'raw'
+
+                // GSEA
+                gsea_rnd_seed              = '10'
+
+                // Report options
+                report_contributors        = 'Jane Doe\nDirector of Institute of Microbiology\nUniversity of Smallville;John Smith\nPhD student\nInstitute of Microbiology\nUniversity of Smallville'
+                report_grouping_variable   = 'treatment'
+
+                // Other
+                round_digits               = 3
             }
+            profile 'rnaseq_limma_gsea'
         }
 
         then {
@@ -99,15 +171,34 @@ nextflow_pipeline {
         }
     }
 
-    test("Test rnaseq limma profile - with decoupler") {
+    test("Test rnaseq limma profile - rnaseq_limma_decoupler") {
         tag "limma_rnaseq_decoupler"
 
         when {
             params {
-                outdir        = "$outputDir"
-                paramsheet    = "${projectDir}/conf/test_paramsheet.yaml"
-                paramset_name = "limma_rnaseq_decoupler"
+                outdir                     = "$outputDir"
+
+                // Study info
+                study_name                 = 'SRP254919'
+
+                // Input data
+                input                      = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.samplesheet.csv'
+                matrix                     = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.salmon.merged.gene_counts.top1000cov.tsv'
+                transcript_length_matrix   = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.spoofed_lengths.tsv'
+                contrasts_yml              = 'https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/differentialabundance/testdata/SRP254919.contrasts.yaml'
+                gtf                        = 'https://ftp.ensembl.org/pub/release-81/gtf/mus_musculus/Mus_musculus.GRCm38.81.gtf.gz'
+                decoupler_network          = 'https://github.com/nf-core/test-datasets/raw/differentialabundance/modules_testdata/progeny/mouse_network.tsv'
+
+                // Filtering
+                filtering_min_abundance    = 10
+
+                // Report options
+                report_contributors        = 'Jane Doe\nDirector of Institute of Microbiology\nUniversity of Smallville;John Smith\nPhD student\nInstitute of Microbiology\nUniversity of Smallville'
+
+                // Other
+                round_digits               = 3
             }
+            profile 'rnaseq_limma_decoupler'
         }
 
         then {
@@ -131,13 +222,38 @@ nextflow_pipeline {
         }
     }
 
-    test("Test rnaseq limma profile - limma_rnaseq_gsea - Numeric sample IDs") {
+    test("Test rnaseq limma profile - rnaseq_limma_gsea - Numeric sample IDs") {
         when {
             params {
-                outdir        = "$outputDir"
-                paramsheet    = "${projectDir}/conf/test_paramsheet.yaml"
-                paramset_name = "limma_rnaseq_gsea_numeric_samples"
+                outdir                     = "$outputDir"
+
+                // Study info
+                study_name                 = 'SRP254919'
+
+                // Input data (local files with numeric sample IDs)
+                input                      = '${projectDir}/tests/assets/SRP254919.samplesheet.csv'
+                matrix                     = '${projectDir}/tests/assets/SRP254919.salmon.merged.gene_counts.top1000cov.tsv'
+                transcript_length_matrix   = '${projectDir}/tests/assets/SRP254919.spoofed_lengths.tsv'
+                contrasts_yml              = 'https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/differentialabundance/testdata/SRP254919.contrasts.yaml'
+                gtf                        = 'https://ftp.ensembl.org/pub/release-81/gtf/mus_musculus/Mus_musculus.GRCm38.81.gtf.gz'
+                gene_sets_files            = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/gene_set_analysis/mh.all.v2022.1.Mm.symbols.gmt'
+
+                // Filtering
+                filtering_min_abundance    = 10
+
+                // Exploratory
+                exploratory_main_variable  = 'contrasts'
+
+                // GSEA
+                gsea_rnd_seed              = '10'
+
+                // Report options
+                report_contributors        = 'Jane Doe\nDirector of Institute of Microbiology\nUniversity of Smallville;John Smith\nPhD student\nInstitute of Microbiology\nUniversity of Smallville'
+
+                // Other
+                round_digits               = 3
             }
+            profile 'rnaseq_limma_gsea'
         }
 
         then {

--- a/tests/test_soft.nf.test
+++ b/tests/test_soft.nf.test
@@ -6,14 +6,18 @@ nextflow_pipeline {
     tag "pipeline"
 
 
-    test("Test soft profile - limma_soft") {
+    test("Test soft profile - soft") {
 
         when {
             params {
-                outdir        = "$outputDir"
-                paramsheet    = "${projectDir}/conf/test_paramsheet.yaml"
-                paramset_name = "limma_soft"
+                outdir                     = "$outputDir"
+
+                // Input data
+                input                      = 'https://raw.githubusercontent.com/nf-core/test-datasets/differentialabundance/testdata/GSE50790.csv'
+                contrasts_yml              = 'https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/differentialabundance/testdata/GSE50790_contrasts.yaml'
+                querygse                   = 'GSE50790'
             }
+            profile 'soft'
         }
 
         then {


### PR DESCRIPTION
## Summary

This PR converts all pipeline tests from paramsheet-based to profile-based configuration, as part of the dual-mode architecture implementation for #472.

## Changes

### Profile Configs Added
- Added profile configs for all analysis types (affy, maxquant, rnaseq, soft)
- Each profile inherits from a base config and sets specific parameters

### Tests Updated

| Test File | Changes |
|-----------|---------|
| `default.nf.test` | 'Test profile - with formula' now uses `rnaseq_deseq2_gprofiler2` profile |
| `test_affy.nf.test` | Uses `affy_limma_gsea` and `affy_limma_gprofiler2` profiles |
| `test_maxquant.nf.test` | Uses `maxquant` profile |
| `test_nogtf.nf.test` | Uses `rnaseq_nogtf` profile |
| `test_rnaseq_deseq2.nf.test` | Uses `rnaseq_deseq2_gsea` and `rnaseq_deseq2_gprofiler2` profiles; split 'Numeric sample IDs' into two tests |
| `test_rnaseq_dream.nf.test` | Uses `rnaseq_dream` and `rnaseq_dream_decoupler` profiles |
| `test_rnaseq_limma.nf.test` | Uses `rnaseq_limma_gsea`, `rnaseq_limma_gprofiler2`, and `rnaseq_limma_decoupler` profiles |
| `test_soft.nf.test` | Uses `soft` profile |

### Key Changes
- All tests now define input data and parameters directly instead of using paramsheet
- Test names updated to match profile names
- Combined profile tests (e.g. `gsea,gprofiler2`) converted to single profile tests
- Input data URLs moved from testdata.yaml to test files

## Notes
- `test_many.nf.test` was NOT modified (as requested)
- Snapshots will need to be updated after running the tests

---
*This PR was created by Luna (AI assistant for @suzannejin)*