### PR TITLE
[Luna] Convert tests from paramsheet to profile-based configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [[#628](https://github.com/nf-core/differentialabundance/pull/628)] - Removed `--deseq2_cores` parameter and infer from task cpus instead,([@delfiterradas](https://github.com/delfiterradas), review by [@grst](https://github.com/grst) and [@pinin4fjords](https://github.com/pinin4fjords)).
 - [[#625](https://github.com/nf-core/differentialabundance/pull/625)] - Sort genes by p-value by default in quarto report, ([@delfiterradas](https://github.com/delfiterradas), review by [@grst](https://github.com/grst) and [@pinin4fjords](https://github.com/pinin4fjords)).
 - [[#620](https://github.com/nf-core/differentialabundance/pull/620/)] - Improve scree plot by switching to plotly, ([@atrigila](https://github.com/atrigila) review by [@apeltzer](https://github.com/apeltzer)).
 - [[#619](https://github.com/nf-core/differentialabundance/pull/619/)] - Improve caching behaviour for processes using `VALIDATOR` outputs ([@atrigila](https://github.com/atrigila), review by [@grst](https://github.com/grst) and [@pinin4fjords](https://github.com/pinin4fjords)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [[#633](https://github.com/nf-core/differentialabundance/pull/633)] - Rename transcript_length_matrix param to feature_length_matrix, ([@delfiterradas](https://github.com/delfiterradas), review by [@grst](https://github.com/grst) and [@pinin4fjords](https://github.com/pinin4fjords)).
 - [[#625](https://github.com/nf-core/differentialabundance/pull/625)] - Sort genes by p-value by default in quarto report, ([@delfiterradas](https://github.com/delfiterradas), review by [@grst](https://github.com/grst) and [@pinin4fjords](https://github.com/pinin4fjords)).
 - [[#620](https://github.com/nf-core/differentialabundance/pull/620/)] - Improve scree plot by switching to plotly, ([@atrigila](https://github.com/atrigila) review by [@apeltzer](https://github.com/apeltzer)).
 - [[#619](https://github.com/nf-core/differentialabundance/pull/619/)] - Improve caching behaviour for processes using `VALIDATOR` outputs ([@atrigila](https://github.com/atrigila), review by [@grst](https://github.com/grst) and [@pinin4fjords](https://github.com/pinin4fjords)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [[#625](https://github.com/nf-core/differentialabundance/pull/625)] - Sort genes by p-value by default in quarto report, ([@delfiterradas](https://github.com/delfiterradas), review by [@grst](https://github.com/grst) and [@pinin4fjords](https://github.com/pinin4fjords)).
 - [[#620](https://github.com/nf-core/differentialabundance/pull/620/)] - Improve scree plot by switching to plotly, ([@atrigila](https://github.com/atrigila) review by [@apeltzer](https://github.com/apeltzer)).
 - [[#619](https://github.com/nf-core/differentialabundance/pull/619/)] - Improve caching behaviour for processes using `VALIDATOR` outputs ([@atrigila](https://github.com/atrigila), review by [@grst](https://github.com/grst) and [@pinin4fjords](https://github.com/pinin4fjords)).
 - [[#615](https://github.com/nf-core/differentialabundance/pull/615/)] - Volcano plot now shows gene name when hovering over points, review by [@grst](https://github.com/grst).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [[#631](https://github.com/nf-core/differentialabundance/pull/631)] - Split zero intercept contrast dream test into two, ([@delfiterradas](https://github.com/delfiterradas), review by [@grst](https://github.com/grst) and [@pinin4fjords](https://github.com/pinin4fjords)).
 - [[#625](https://github.com/nf-core/differentialabundance/pull/625)] - Sort genes by p-value by default in quarto report, ([@delfiterradas](https://github.com/delfiterradas), review by [@grst](https://github.com/grst) and [@pinin4fjords](https://github.com/pinin4fjords)).
 - [[#620](https://github.com/nf-core/differentialabundance/pull/620/)] - Improve scree plot by switching to plotly, ([@atrigila](https://github.com/atrigila) review by [@apeltzer](https://github.com/apeltzer)).
 - [[#619](https://github.com/nf-core/differentialabundance/pull/619/)] - Improve caching behaviour for processes using `VALIDATOR` outputs ([@atrigila](https://github.com/atrigila), review by [@grst](https://github.com/grst) and [@pinin4fjords](https://github.com/pinin4fjords)).

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ RNA-seq with deseq2:
 :::note
 If you are using the outputs of the nf-core rnaseq workflow as input here **either**:
 
-- supply the raw count matrices (file names like **gene_counts.tsv**) alongide the transcript length matrix via `--transcript_length_matrix` (rnaseq versions >=3.12.0, preferred)
+- supply the raw count matrices (file names like **gene_counts.tsv**) alongide the feature length matrix via `--feature_length_matrix` (rnaseq versions >=3.12.0, preferred)
 - **or** supply the **gene_counts_length_scaled.tsv** or **gene_counts_scaled.tsv** matrices.
 
 RNA-seq limma+voom:

--- a/assets/differentialabundance_report.qmd
+++ b/assets/differentialabundance_report.qmd
@@ -1229,6 +1229,10 @@ for (i in 1:nrow(contrasts)) {
                     "Down"   # Negative fold-change = Down-regulated
                 )
             ) %>%
+            arrange(
+                .data[[params$meta$params$differential_qval_column]],
+                .data[[params$meta$params$differential_pval_column]]
+            ) %>%
             relocate(Direction) %>%
             rename_with(prettifyVariablename)
 

--- a/conf/affy/affy.config
+++ b/conf/affy/affy.config
@@ -1,0 +1,41 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Affymetrix microarray analysis profile (default: Limma)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Sets parameters for Affymetrix array differential abundance analysis using Limma.
+    Use as follows:
+        nextflow run nf-core/differentialabundance -profile affy,<docker/singularity> --input <SAMPLESHEET> --affy_cel_files_archive <TAR> --outdir <OUTDIR>
+----------------------------------------------------------------------------------------
+*/
+
+params {
+    paramset_name                    = 'affy'
+
+    // Study
+    study_type                       = 'affy_array'
+    study_abundance_type             = 'intensities'
+
+    // Differential analysis (Limma)
+    differential_method              = 'limma'
+
+    // Features
+    features_id_col                  = 'PROBEID'
+    features_metadata_cols           = 'PROBEID,ENSEMBL,SYMBOL,GENETYPE'
+    features_name_col                = 'SYMBOL'
+    differential_feature_id_column   = 'PROBEID'
+    differential_feature_name_column = 'SYMBOL'
+
+    // Exploratory
+    exploratory_assay_names          = 'raw,normalised'
+    exploratory_final_assay          = 'normalised'
+    exploratory_log2_assays          = null
+
+    // Differential output columns
+    differential_file_suffix         = '.limma.results.tsv'
+    differential_fc_column           = 'logFC'
+    differential_pval_column         = 'P.Value'
+    differential_qval_column         = 'adj.P.Val'
+
+    // Shiny app
+    shinyngs_build_app               = true
+}

--- a/conf/affy/affy_limma_gprofiler2.config
+++ b/conf/affy/affy_limma_gprofiler2.config
@@ -1,0 +1,14 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Affymetrix Limma + g:Profiler2 analysis profile
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Inherits from affy.config and adds g:Profiler2 functional enrichment.
+----------------------------------------------------------------------------------------
+*/
+
+includeConfig 'affy.config'
+
+params {
+    paramset_name     = 'affy_limma_gprofiler2'
+    functional_method = 'gprofiler2'
+}

--- a/conf/affy/affy_limma_gsea.config
+++ b/conf/affy/affy_limma_gsea.config
@@ -1,0 +1,14 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Affymetrix Limma + GSEA analysis profile
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Inherits from affy.config and adds GSEA functional enrichment.
+----------------------------------------------------------------------------------------
+*/
+
+includeConfig 'affy.config'
+
+params {
+    paramset_name     = 'affy_limma_gsea'
+    functional_method = 'gsea'
+}

--- a/conf/maxquant/maxquant.config
+++ b/conf/maxquant/maxquant.config
@@ -1,0 +1,45 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    MaxQuant proteomics analysis profile (default: Limma)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Sets parameters for MaxQuant proteomics differential abundance analysis using Limma.
+    Use as follows:
+        nextflow run nf-core/differentialabundance -profile maxquant,<docker/singularity> --input <SAMPLESHEET> --matrix <MATRIX> --outdir <OUTDIR>
+----------------------------------------------------------------------------------------
+*/
+
+params {
+    paramset_name                    = 'maxquant'
+
+    // Study
+    study_type                       = 'maxquant'
+    study_abundance_type             = 'intensities'
+
+    // Differential analysis (Limma)
+    differential_method              = 'limma'
+
+    // Features
+    features_id_col                  = 'Majority protein IDs'
+    features_name_col                = 'Majority protein IDs'
+    features_metadata_cols           = 'Majority protein IDs'
+    features_type                    = 'protein'
+    differential_feature_id_column   = 'Majority protein IDs'
+    differential_feature_name_column = 'Majority protein IDs'
+
+    // Exploratory
+    exploratory_assay_names          = 'raw,normalised'
+    exploratory_final_assay          = 'normalised'
+    exploratory_log2_assays          = null
+
+    // Differential output columns
+    differential_file_suffix         = '.limma.results.tsv'
+    differential_fc_column           = 'logFC'
+    differential_pval_column         = 'P.Value'
+    differential_qval_column         = 'adj.P.Val'
+
+    // Proteus
+    proteus_measurecol_prefix        = 'LFQ intensity'
+
+    // Shiny app
+    shinyngs_build_app               = false
+}

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -227,7 +227,7 @@ process {
             "--vs_blind $meta.params.deseq2_vs_blind",
             "--vst_nsub $meta.params.deseq2_vst_nsub",
             "--shrink_lfc $meta.params.deseq2_shrink_lfc",
-            "--cores $meta.params.deseq2_cores",
+            "--cores $task.cpus",
             ((meta.params.round_digits != null && meta.params.round_digits > 0) ? "--round_digits $meta.params.round_digits" : ""),
             ((meta.blocking == null) ? '' : "--blocking_variables $meta.blocking"),
         ].join(' ').trim() }
@@ -271,7 +271,7 @@ process {
             "--vs_blind $meta.params.deseq2_vs_blind",
             "--vst_nsub $meta.params.deseq2_vst_nsub",
             "--shrink_lfc $meta.params.deseq2_shrink_lfc",
-            "--cores $meta.params.deseq2_cores",
+            "--cores $task.cpus",
             "--seed $meta.params.deseq2_seed",
             "--subset_to_contrast_samples $meta.params.differential_subset_to_contrast_samples",
             ((meta.params.round_digits != null && meta.params.round_digits > 0) ? "--round_digits $meta.params.round_digits" : ""),

--- a/conf/rnaseq/rnaseq.config
+++ b/conf/rnaseq/rnaseq.config
@@ -1,0 +1,43 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    RNA-seq analysis profile (default: DESeq2)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Sets parameters for RNA-seq differential abundance analysis using DESeq2.
+    Use as follows:
+        nextflow run nf-core/differentialabundance -profile rnaseq,<docker/singularity> --input <SAMPLESHEET> --matrix <MATRIX> --outdir <OUTDIR>
+----------------------------------------------------------------------------------------
+*/
+
+params {
+    paramset_name                    = 'rnaseq'
+
+    // Study
+    study_type                       = 'rnaseq'
+    study_abundance_type             = 'counts'
+
+    // Features
+    features_type                    = 'gene'
+    features_id_col                  = 'gene_id'
+    features_name_col                = 'gene_name'
+    features_metadata_cols           = 'gene_id,gene_name,gene_biotype'
+    differential_feature_id_column   = 'gene_id'
+    differential_feature_name_column = 'gene_name'
+
+    // Observations
+    observations_id_col              = 'sample'
+    observations_name_col            = 'sample'
+
+    // Differential analysis (DESeq2)
+    differential_method              = 'deseq2'
+
+    // Exploratory
+    exploratory_assay_names          = 'raw,normalised,variance_stabilised'
+    exploratory_final_assay          = 'variance_stabilised'
+    exploratory_log2_assays          = 'raw,normalised'
+
+    // Differential output columns
+    differential_file_suffix         = '.deseq2.results.tsv'
+    differential_fc_column           = 'log2FoldChange'
+    differential_pval_column         = 'pvalue'
+    differential_qval_column         = 'padj'
+}

--- a/conf/rnaseq/rnaseq_deseq2_gprofiler2.config
+++ b/conf/rnaseq/rnaseq_deseq2_gprofiler2.config
@@ -1,0 +1,14 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    RNA-seq DESeq2 + g:Profiler2 analysis profile
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Inherits from rnaseq.config (DESeq2) and adds g:Profiler2 functional enrichment.
+----------------------------------------------------------------------------------------
+*/
+
+includeConfig 'rnaseq.config'
+
+params {
+    paramset_name     = 'rnaseq_deseq2_gprofiler2'
+    functional_method = 'gprofiler2'
+}

--- a/conf/rnaseq/rnaseq_deseq2_gsea.config
+++ b/conf/rnaseq/rnaseq_deseq2_gsea.config
@@ -1,0 +1,14 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    RNA-seq DESeq2 + GSEA analysis profile
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Inherits from rnaseq.config (DESeq2) and adds GSEA functional enrichment.
+----------------------------------------------------------------------------------------
+*/
+
+includeConfig 'rnaseq.config'
+
+params {
+    paramset_name     = 'rnaseq_deseq2_gsea'
+    functional_method = 'gsea'
+}

--- a/conf/rnaseq/rnaseq_dream.config
+++ b/conf/rnaseq/rnaseq_dream.config
@@ -1,0 +1,29 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    RNA-seq DREAM analysis profile
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Inherits RNA-seq base settings from rnaseq.config and overrides with DREAM-specific
+    differential analysis parameters (mixed-effects models).
+----------------------------------------------------------------------------------------
+*/
+
+includeConfig 'rnaseq.config'
+
+params {
+    paramset_name            = 'rnaseq_dream'
+
+    // Differential analysis (DREAM)
+    differential_method      = 'dream'
+    dream_apply_voom         = true
+
+    // Exploratory
+    exploratory_assay_names  = 'raw,normalised'
+    exploratory_final_assay  = 'normalised'
+    exploratory_log2_assays  = 'raw'
+
+    // Differential output columns
+    differential_file_suffix = '.dream.results.tsv'
+    differential_fc_column   = 'logFC'
+    differential_pval_column = 'P.Value'
+    differential_qval_column = 'adj.P.Val'
+}

--- a/conf/rnaseq/rnaseq_dream_decoupler.config
+++ b/conf/rnaseq/rnaseq_dream_decoupler.config
@@ -1,0 +1,14 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    RNA-seq DREAM + Decoupler analysis profile
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Inherits from rnaseq_dream.config and adds Decoupler functional enrichment.
+----------------------------------------------------------------------------------------
+*/
+
+includeConfig 'rnaseq_dream.config'
+
+params {
+    paramset_name     = 'rnaseq_dream_decoupler'
+    functional_method = 'decoupler'
+}

--- a/conf/rnaseq/rnaseq_limma.config
+++ b/conf/rnaseq/rnaseq_limma.config
@@ -1,0 +1,29 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    RNA-seq Limma analysis profile
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Inherits RNA-seq base settings from rnaseq.config and overrides with Limma-specific
+    differential analysis parameters.
+----------------------------------------------------------------------------------------
+*/
+
+includeConfig 'rnaseq.config'
+
+params {
+    paramset_name            = 'rnaseq_limma'
+
+    // Differential analysis (Limma)
+    differential_method      = 'limma'
+    limma_use_voom           = true
+
+    // Exploratory
+    exploratory_assay_names  = 'raw,normalised'
+    exploratory_final_assay  = 'normalised'
+    exploratory_log2_assays  = 'raw'
+
+    // Differential output columns
+    differential_file_suffix = '.limma.results.tsv'
+    differential_fc_column   = 'logFC'
+    differential_pval_column = 'P.Value'
+    differential_qval_column = 'adj.P.Val'
+}

--- a/conf/rnaseq/rnaseq_limma_decoupler.config
+++ b/conf/rnaseq/rnaseq_limma_decoupler.config
@@ -1,0 +1,14 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    RNA-seq Limma + Decoupler analysis profile
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Inherits from rnaseq_limma.config and adds Decoupler functional enrichment.
+----------------------------------------------------------------------------------------
+*/
+
+includeConfig 'rnaseq_limma.config'
+
+params {
+    paramset_name     = 'rnaseq_limma_decoupler'
+    functional_method = 'decoupler'
+}

--- a/conf/rnaseq/rnaseq_limma_gprofiler2.config
+++ b/conf/rnaseq/rnaseq_limma_gprofiler2.config
@@ -1,0 +1,14 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    RNA-seq Limma + g:Profiler2 analysis profile
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Inherits from rnaseq_limma.config and adds g:Profiler2 functional enrichment.
+----------------------------------------------------------------------------------------
+*/
+
+includeConfig 'rnaseq_limma.config'
+
+params {
+    paramset_name     = 'rnaseq_limma_gprofiler2'
+    functional_method = 'gprofiler2'
+}

--- a/conf/rnaseq/rnaseq_limma_gsea.config
+++ b/conf/rnaseq/rnaseq_limma_gsea.config
@@ -1,0 +1,14 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    RNA-seq Limma + GSEA analysis profile
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Inherits from rnaseq_limma.config and adds GSEA functional enrichment.
+----------------------------------------------------------------------------------------
+*/
+
+includeConfig 'rnaseq_limma.config'
+
+params {
+    paramset_name     = 'rnaseq_limma_gsea'
+    functional_method = 'gsea'
+}

--- a/conf/rnaseq/rnaseq_nogtf.config
+++ b/conf/rnaseq/rnaseq_nogtf.config
@@ -1,0 +1,13 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    RNA-seq analysis profile without GTF annotation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Inherits from rnaseq.config (DESeq2). Use when no GTF annotation is available.
+----------------------------------------------------------------------------------------
+*/
+
+includeConfig 'rnaseq.config'
+
+params {
+    paramset_name = 'rnaseq_nogtf'
+}

--- a/conf/soft/soft.config
+++ b/conf/soft/soft.config
@@ -1,0 +1,42 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    GEO SOFT file analysis profile (default: Limma)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Sets parameters for GEO SOFT file differential abundance analysis using Limma.
+    Use as follows:
+        nextflow run nf-core/differentialabundance -profile soft,<docker/singularity> --input <SAMPLESHEET> --querygse <GSE_ID> --outdir <OUTDIR>
+----------------------------------------------------------------------------------------
+*/
+
+params {
+    paramset_name                    = 'soft'
+
+    // Study
+    study_type                       = 'geo_soft_file'
+    study_abundance_type             = 'intensities'
+
+    // Differential analysis (Limma)
+    differential_method              = 'limma'
+
+    // Observations
+    observations_id_col              = 'id'
+    observations_name_col            = 'id'
+
+    // Features
+    features_id_col                  = 'ID'
+    features_metadata_cols           = 'ID,ENTREZ_GENE_ID,Gene Symbol,Sequence Type'
+    features_name_col                = 'Gene Symbol'
+    differential_feature_id_column   = 'ID'
+    differential_feature_name_column = 'Symbol'
+
+    // Exploratory
+    exploratory_assay_names          = 'normalised'
+    exploratory_final_assay          = 'normalised'
+    exploratory_log2_assays          = null
+
+    // Differential output columns
+    differential_file_suffix         = '.limma.results.tsv'
+    differential_fc_column           = 'logFC'
+    differential_pval_column         = 'P.Value'
+    differential_qval_column         = 'adj.P.Val'
+}

--- a/conf/test.config
+++ b/conf/test.config
@@ -20,7 +20,7 @@ params {
     // Input data
     input                    = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.samplesheet.csv'
     matrix                   = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.salmon.merged.gene_counts.top1000cov.tsv'
-    transcript_length_matrix = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.spoofed_lengths.tsv'
+    feature_length_matrix    = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.spoofed_lengths.tsv'
     contrasts_yml            = 'https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/differentialabundance/testdata/SRP254919.contrasts.yaml'
 
     // To do: replace this with a cut-down mouse GTF matching the matrix for testing

--- a/conf/test.config
+++ b/conf/test.config
@@ -10,9 +10,9 @@
 ----------------------------------------------------------------------------------------
 */
 
-params {
-    paramset_name = "deseq2_rnaseq_gsea"
+includeConfig 'rnaseq/rnaseq_deseq2_gsea.config'
 
+params {
     study_name                 = 'SRP254919'
     config_profile_name        = 'Test profile'
     config_profile_description = 'Minimal test dataset to check pipeline function'

--- a/conf/test_paramsheet.yaml
+++ b/conf/test_paramsheet.yaml
@@ -354,6 +354,27 @@
   # Other
   round_digits: 3
 
+- paramset_name: dream_norm2
+  include: paramsheet/dream_norm,testdata/rnaseq_testdata_complex3
+
+  # Filtering
+  filtering_min_abundance: 10
+
+  # Exploratory
+  exploratory_main_variable: contrasts
+
+  # Report options
+  report_contributors: |-
+    Jane Doe
+    Director of Institute of Microbiology
+    University of Smallville;John Smith
+    PhD student
+    Institute of Microbiology
+    University of Smallville
+
+  # Other
+  round_digits: 3
+
 - paramset_name: limma_affy_gsea
   include: paramsheet/limma_affy_gsea,testdata/affy_testdata
 

--- a/conf/testdata.yaml
+++ b/conf/testdata.yaml
@@ -2,7 +2,7 @@
   study_name: SRP254919
   input: ${projectDir}/tests/assets/SRP254919.samplesheet.csv
   matrix: ${projectDir}/tests/assets/SRP254919.salmon.merged.gene_counts.top1000cov.tsv
-  transcript_length_matrix: ${projectDir}/tests/assets/SRP254919.spoofed_lengths.tsv
+  feature_length_matrix: ${projectDir}/tests/assets/SRP254919.spoofed_lengths.tsv
   contrasts_yml: https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/differentialabundance/testdata/SRP254919.contrasts.yaml
   gtf: https://ftp.ensembl.org/pub/release-81/gtf/mus_musculus/Mus_musculus.GRCm38.81.gtf.gz
   gene_sets_files: https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/gene_set_analysis/mh.all.v2022.1.Mm.symbols.gmt
@@ -21,7 +21,7 @@
   study_name: SRP254919
   input: https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.samplesheet.csv
   matrix: https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.salmon.merged.gene_counts.top1000cov.tsv
-  transcript_length_matrix: https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.spoofed_lengths.tsv
+  feature_length_matrix: https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.spoofed_lengths.tsv
   contrasts_yml: https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/differentialabundance/testdata/SRP254919.contrasts.yaml
   gtf: https://ftp.ensembl.org/pub/release-81/gtf/mus_musculus/Mus_musculus.GRCm38.81.gtf.gz
   gene_sets_files: https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/gene_set_analysis/mh.all.v2022.1.Mm.symbols.gmt

--- a/conf/testdata.yaml
+++ b/conf/testdata.yaml
@@ -40,7 +40,16 @@
   study_name: SRP254919
   input: https://github.com/nf-core/test-datasets/raw/differentialabundance/modules_testdata/variancepartition_dream/metadata.tsv
   matrix: https://github.com/nf-core/test-datasets/raw/differentialabundance/modules_testdata/variancepartition_dream/counts.tsv
-  contrasts_yml: ${projectDir}/tests/assets/zero_intercept_contrasts.yml
+  contrasts_yml: ${projectDir}/tests/assets/zero_intercept_contrasts_1.yml
+  gtf: https://ftp.ensembl.org/pub/release-81/gtf/mus_musculus/Mus_musculus.GRCm38.81.gtf.gz
+  gene_sets_files: https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/gene_set_analysis/mh.all.v2022.1.Mm.symbols.gmt
+  decoupler_network: https://github.com/nf-core/test-datasets/raw/differentialabundance/modules_testdata/progeny/mouse_network.tsv
+
+- paramset_name: rnaseq_testdata_complex3
+  study_name: SRP254919
+  input: https://github.com/nf-core/test-datasets/raw/differentialabundance/modules_testdata/variancepartition_dream/metadata.tsv
+  matrix: https://github.com/nf-core/test-datasets/raw/differentialabundance/modules_testdata/variancepartition_dream/counts.tsv
+  contrasts_yml: ${projectDir}/tests/assets/zero_intercept_contrasts_2.yml
   gtf: https://ftp.ensembl.org/pub/release-81/gtf/mus_musculus/Mus_musculus.GRCm38.81.gtf.gz
   gene_sets_files: https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/gene_set_analysis/mh.all.v2022.1.Mm.symbols.gmt
   decoupler_network: https://github.com/nf-core/test-datasets/raw/differentialabundance/modules_testdata/progeny/mouse_network.tsv

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -77,10 +77,10 @@ To use this approach, include the corresponding lengths file with the **raw coun
 
 ```bash
 --matrix 'salmon.merged.gene_counts.tsv' \
---transcript_length_matrix 'salmon.merged.gene_lengths.tsv'
+--feature_length_matrix 'salmon.merged.gene_lengths.tsv'
 ```
 
-Without the transcript/gene lengths, for instance in earlier rnaseq workflow versions, follow the second recommendation in the [tximport documentation](https://bioconductor.org/packages/release/bioc/vignettes/tximport/inst/doc/tximport.html#Downstream_DGE_in_Bioconductor):
+Without the feature lengths, for instance in earlier rnaseq workflow versions, follow the second recommendation in the [tximport documentation](https://bioconductor.org/packages/release/bioc/vignettes/tximport/inst/doc/tximport.html#Downstream_DGE_in_Bioconductor):
 
 > "Use the tximport argument `countsFromAbundance='lengthScaledTPM'` or `'scaledTPM'`, then employ the gene-level count matrix `txi$counts` directly in downstream software, a method we call 'bias corrected counts without an offset'"
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -19,7 +19,7 @@ params {
     contrasts_yml              = null
     querygse                   = null
     matrix                     = null
-    transcript_length_matrix   = null
+    feature_length_matrix      = null
     control_features           = null
     sizefactors_from_controls  = false
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -29,7 +29,7 @@ params {
 
     // Paramsheet options
     paramset_name              = null
-    paramsheet                 = "${projectDir}/conf/paramsheet.yaml"
+    paramsheet                 = null
 
     // Sample sheet options
     observations_type          = 'sample'
@@ -370,6 +370,24 @@ profiles {
         singularity.runOptions  = '--nv'
     }
 
+    // Analysis profiles (single-run mode)
+    rnaseq                    { includeConfig 'conf/rnaseq/rnaseq.config'                    }
+    rnaseq_nogtf              { includeConfig 'conf/rnaseq/rnaseq_nogtf.config'              }
+    rnaseq_deseq2_gsea        { includeConfig 'conf/rnaseq/rnaseq_deseq2_gsea.config'        }
+    rnaseq_deseq2_gprofiler2  { includeConfig 'conf/rnaseq/rnaseq_deseq2_gprofiler2.config'  }
+    rnaseq_limma              { includeConfig 'conf/rnaseq/rnaseq_limma.config'              }
+    rnaseq_limma_gsea         { includeConfig 'conf/rnaseq/rnaseq_limma_gsea.config'         }
+    rnaseq_limma_gprofiler2   { includeConfig 'conf/rnaseq/rnaseq_limma_gprofiler2.config'   }
+    rnaseq_limma_decoupler    { includeConfig 'conf/rnaseq/rnaseq_limma_decoupler.config'    }
+    rnaseq_dream              { includeConfig 'conf/rnaseq/rnaseq_dream.config'              }
+    rnaseq_dream_decoupler    { includeConfig 'conf/rnaseq/rnaseq_dream_decoupler.config'    }
+    affy                      { includeConfig 'conf/affy/affy.config'                        }
+    affy_limma_gsea           { includeConfig 'conf/affy/affy_limma_gsea.config'             }
+    affy_limma_gprofiler2     { includeConfig 'conf/affy/affy_limma_gprofiler2.config'       }
+    maxquant                  { includeConfig 'conf/maxquant/maxquant.config'                }
+    soft                      { includeConfig 'conf/soft/soft.config'                        }
+
+    // Test profiles
     test              { includeConfig 'conf/test.config'              }
     test_full         { includeConfig 'conf/test_full.config'         }
     cache_default     { includeConfig 'conf/cache_default.config'     }

--- a/nextflow.config
+++ b/nextflow.config
@@ -116,7 +116,6 @@ params {
     deseq2_minmu                      = 0.5
     deseq2_vs_method                  = 'vst' // 'rlog', 'vst', or 'rlog,vst'
     deseq2_shrink_lfc                 = true
-    deseq2_cores                      = 1
     deseq2_vs_blind                   = true
     deseq2_vst_nsub                   = 1000
     deseq2_seed                       = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -93,7 +93,7 @@
                     "pattern": "^\\S+\\.(tsv|csv)$|\\S*proteinGroups\\.txt$",
                     "fa_icon": "fas fa-border-all"
                 },
-                "transcript_length_matrix": {
+                "feature_length_matrix": {
                     "type": "string",
                     "fa_icon": "fas fa-border-all",
                     "description": "(RNA-seq only): optional transcript/gene length matrix with samples and transcript_ids/gene_ids as in the abundance matrix.",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -206,12 +206,12 @@
             "properties": {
                 "paramset_name": {
                     "type": "string",
-                    "description": "Name of the paramset (as specified in assets/paramsheet) to run specific analyses"
+                    "description": "Name of the paramset to run. In profile mode, set by the analysis profile for output directory naming. In paramsheet mode, selects which paramset(s) to run (comma-separated)."
                 },
                 "paramsheet": {
                     "type": "string",
-                    "description": "Path to a paramsheet file",
-                    "help_text": "A YAML file that defines 1+ nextflow config(s).",
+                    "description": "Path to a paramsheet YAML file. Setting this activates multi-run (paramsheet) mode where paramsheet values take priority over CLI flags.",
+                    "help_text": "A YAML file that defines 1+ nextflow config(s). When not set, the pipeline uses standard Nextflow config profiles (single-run mode) where CLI flags have highest priority.",
                     "pattern": "^\\S+\\.(yaml|yml)$",
                     "format": "file-path",
                     "mimetype": "text/csv"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -696,13 +696,6 @@
                     "help_text": "'ashr' method is the only method currently implemented",
                     "fa_icon": "fas fa-microscope"
                 },
-                "deseq2_cores": {
-                    "type": "integer",
-                    "default": 1,
-                    "description": "Number of cores",
-                    "help_text": "Number of cores to use with DESeq()",
-                    "fa_icon": "fab fa-centercode"
-                },
                 "deseq2_seed": {
                     "type": "integer",
                     "fa_icon": "fas fa-seedling"

--- a/subworkflows/local/utils_nfcore_differentialabundance_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_differentialabundance_pipeline/main.nf
@@ -340,8 +340,8 @@ def methodsDescriptionText(mqc_methods_yaml) {
 // Get configurations based on whether use paramsheet or default params
 // and validate them against the schema.
 def getParamsetConfigurations() {
-    // Use paramsheet if paramset_name is provided, otherwise use default params
-    def paramsets = (params.paramset_name) ? getParamsheetConfigurations() : getDefaultConfigurations()
+    // Use paramsheet if --paramsheet is explicitly provided, otherwise use default params (profile mode)
+    def paramsets = (params.paramsheet) ? getParamsheetConfigurations() : getDefaultConfigurations()
 
     return paramsets.collect { paramset ->
         // Some params are not useful through the pipeline run.
@@ -379,7 +379,7 @@ def getParamsheetConfigurations() {
 
     def paramsheet = raw_paramsheet
         .findAll { row ->
-            if (params.paramset_name == 'all') {
+            if (!params.paramset_name || params.paramset_name == 'all') {
                 return true
             } else {
                 // Only keep row matching with paramset name(s)
@@ -404,10 +404,11 @@ def getParamsheetConfigurations() {
         }
 }
 
-// Get default configurations from pipeline parameters
+// Get default configurations from pipeline parameters (profile mode)
 def getDefaultConfigurations() {
-    // replace null by string 'contrasts' for paramset_name to avoid certain problems with null object
-    return [params + [paramset_name: 'contrasts']]
+    // Use paramset_name from profile if set, otherwise fall back to 'contrasts'
+    def pname = params.paramset_name ?: 'contrasts'
+    return [params + [paramset_name: pname]]
 }
 
 // Load configurations from yaml file

--- a/tests/assets/zero_intercept_contrasts_1.yml
+++ b/tests/assets/zero_intercept_contrasts_1.yml
@@ -1,0 +1,11 @@
+contrasts:
+  - id: treatment_effect_classic_comparison
+    comparison: ["treatment", "Control", "Treated"]
+
+  - id: treatment_plus_genotype
+    formula: "~ treatment + genotype"
+    make_contrasts_str: "treatmentTreated"
+
+  - id: interaction_genotype_treatment
+    formula: "~ genotype * treatment"
+    make_contrasts_str: "genotypeWT.treatmentTreated"

--- a/tests/assets/zero_intercept_contrasts_2.yml
+++ b/tests/assets/zero_intercept_contrasts_2.yml
@@ -1,15 +1,4 @@
 contrasts:
-  - id: treatment_effect_classic_comparison
-    comparison: ["treatment", "Control", "Treated"]
-
-  - id: treatment_plus_genotype
-    formula: "~ treatment + genotype"
-    make_contrasts_str: "treatmentTreated"
-
-  - id: interaction_genotype_treatment
-    formula: "~ genotype * treatment"
-    make_contrasts_str: "genotypeWT.treatmentTreated"
-
   - id: full_model_with_interactions
     formula: "~ genotype * treatment * time"
     make_contrasts_str: "genotypeWT.treatmentTreated.time"

--- a/tests/default.nf.test
+++ b/tests/default.nf.test
@@ -15,27 +15,21 @@ nextflow_pipeline {
         }
 
         then {
-            // stable_name: All files + folders in ${params.outdir}/ with a stable name
             def stable_name = getAllFilesFromDir(params.outdir, relative: true, includeDir: true, ignore: ['pipeline_info/*.{html,json,txt}'])
-            // stable_path: All files in ${params.outdir}/ with stable content
             def stable_path = getAllFilesFromDir(params.outdir, ignoreFile: 'tests/.nftignore')
             assertAll(
                 { assert workflow.success},
                 { assert snapshot(
-                    // Number of successful tasks
                     workflow.trace.succeeded().size(),
-                    // pipeline versions.yml file for multiqc from which Nextflow version is removed because we tests pipelines on multiple Nextflow versions
                     removeNextflowVersion("$outputDir/pipeline_info/nf_core_differentialabundance_software_versions.yml"),
-                    // All stable path name, with a relative path
                     stable_name,
-                    // All files with stable contents
                     stable_path
                 ).match() }
-                )
+            )
         }
     }
 
-    test("Test profile - csv contrasts") { // make sure we keep backwards compatibility with csv contrasts
+    test("Test profile - csv contrasts") {
         config "${projectDir}/conf/test.config"
 
         when {
@@ -47,23 +41,17 @@ nextflow_pipeline {
         }
 
         then {
-            // stable_name: All files + folders in ${params.outdir}/ with a stable name
             def stable_name = getAllFilesFromDir(params.outdir, relative: true, includeDir: true, ignore: ['pipeline_info/*.{html,json,txt}'])
-            // stable_path: All files in ${params.outdir}/ with stable content
             def stable_path = getAllFilesFromDir(params.outdir, ignoreFile: 'tests/.nftignore')
             assertAll(
                 { assert workflow.success},
                 { assert snapshot(
-                    // Number of successful tasks
                     workflow.trace.succeeded().size(),
-                    // pipeline versions.yml file for multiqc from which Nextflow version is removed because we tests pipelines on multiple Nextflow versions
                     removeNextflowVersion("$outputDir/pipeline_info/nf_core_differentialabundance_software_versions.yml"),
-                    // All stable path name, with a relative path
                     stable_name,
-                    // All files with stable contents
                     stable_path
                 ).match() }
-                )
+            )
         }
     }
 
@@ -71,34 +59,59 @@ nextflow_pipeline {
 
         when {
             params {
-                outdir        = "$outputDir"
-                paramsheet    = "${projectDir}/conf/test_paramsheet.yaml"
-                paramset_name = "deseq2_rnaseq_gprofiler2_complex"
+                outdir                     = "$outputDir"
+
+                // Study info
+                study_name                 = 'SRP254919'
+
+                // Input data (complex dataset)
+                input                      = 'https://github.com/nf-core/test-datasets/raw/differentialabundance/modules_testdata/variancepartition_dream/metadata.tsv'
+                matrix                     = 'https://github.com/nf-core/test-datasets/raw/differentialabundance/modules_testdata/variancepartition_dream/counts.tsv'
+                contrasts_yml              = 'https://github.com/nf-core/test-datasets/raw/differentialabundance/testdata/formula_contrasts/rnaseq_complex_contrast.yaml'
+                gtf                        = 'https://ftp.ensembl.org/pub/release-81/gtf/mus_musculus/Mus_musculus.GRCm38.81.gtf.gz'
+
+                // Exploratory plots
+                exploratory_main_variable  = 'contrasts'
+                exploratory_log2_assays    = 'raw'
+
+                // DESeq2
+                deseq2_vst_nsub            = 500
+                deseq2_seed                = 1
+                deseq2_vs_method           = 'rlog'
+                deseq2_shrink_lfc          = false
+
+                // gprofiler2 options
+                gprofiler2_organism        = 'mmusculus'
+
+                // Filtering
+                filtering_min_abundance    = 10
+
+                // Report options
+                report_contributors        = 'Jane Doe\nDirector of Institute of Microbiology\nUniversity of Smallville;John Smith\nPhD student\nInstitute of Microbiology\nUniversity of Smallville'
+
+                // Other
+                round_digits               = 2
+                skip_reports               = true
             }
+            profile 'rnaseq_deseq2_gprofiler2'
         }
 
         then {
-            // stable_name: All files + folders in ${params.outdir}/ with a stable name
             def stable_name = getAllFilesFromDir(params.outdir, relative: true, includeDir: true, ignore: ['pipeline_info/*.{html,json,txt}'])
-            // stable_path: All files in ${params.outdir}/ with stable content
             def stable_path = getAllFilesFromDir(params.outdir, ignoreFile: 'tests/.nftignore')
             assertAll(
                 { assert workflow.success},
                 { assert snapshot(
-                    // Number of successful tasks
                     workflow.trace.succeeded().size(),
-                    // pipeline versions.yml file for multiqc from which Nextflow version is removed because we tests pipelines on multiple Nextflow versions
                     removeNextflowVersion("$outputDir/pipeline_info/nf_core_differentialabundance_software_versions.yml"),
-                    // All stable path name, with a relative path
                     stable_name,
-                    // All files with stable contents
                     stable_path
                 ).match() }
-                )
+            )
         }
     }
 
-    test("Test profile - multiple reports - csv contrasts") { // make sure we keep backwards compatibility with csv contrasts
+    test("Test profile - multiple reports - csv contrasts") {
         config "${projectDir}/conf/test.config"
 
         when {
@@ -111,54 +124,43 @@ nextflow_pipeline {
         }
 
         then {
-            // stable_name: All files + folders in ${params.outdir}/ with a stable name
             def stable_name = getAllFilesFromDir(params.outdir, relative: true, includeDir: true, ignore: ['pipeline_info/*.{html,json,txt}'])
-            // stable_path: All files in ${params.outdir}/ with stable content
             def stable_path = getAllFilesFromDir(params.outdir, ignoreFile: 'tests/.nftignore')
             assertAll(
                 { assert workflow.success},
                 { assert snapshot(
-                    // Number of successful tasks
                     workflow.trace.succeeded().size(),
-                    // pipeline versions.yml file for multiqc from which Nextflow version is removed because we tests pipelines on multiple Nextflow versions
                     removeNextflowVersion("$outputDir/pipeline_info/nf_core_differentialabundance_software_versions.yml"),
-                    // All stable path name, with a relative path
                     stable_name,
-                    // All files with stable contents
                     stable_path
                 ).match() }
-                )
+            )
         }
     }
+
     test("Test profile - filtering_min_abundance false") {
         tag "abundance_false"
         config "${projectDir}/conf/test.config"
 
         when {
             params {
-                outdir        = "$outputDir"
+                outdir                  = "$outputDir"
                 filtering_min_abundance = false
             }
         }
 
         then {
-            // stable_name: All files + folders in ${params.outdir}/ with a stable name
             def stable_name = getAllFilesFromDir(params.outdir, relative: true, includeDir: true, ignore: ['pipeline_info/*.{html,json,txt}'])
-            // stable_path: All files in ${params.outdir}/ with stable content
             def stable_path = getAllFilesFromDir(params.outdir, ignoreFile: 'tests/.nftignore')
             assertAll(
                 { assert workflow.success},
                 { assert snapshot(
-                    // Number of successful tasks
                     workflow.trace.succeeded().size(),
-                    // pipeline versions.yml file for multiqc from which Nextflow version is removed because we tests pipelines on multiple Nextflow versions
                     removeNextflowVersion("$outputDir/pipeline_info/nf_core_differentialabundance_software_versions.yml"),
-                    // All stable path name, with a relative path
                     stable_name,
-                    // All files with stable contents
                     stable_path
                 ).match() }
-                )
+            )
         }
     }
 }

--- a/tests/test_affy.nf.test
+++ b/tests/test_affy.nf.test
@@ -5,70 +5,102 @@ nextflow_pipeline {
     tag "affy"
     tag "pipeline"
 
-    test("Test affy profile - limma_affy_gsea") {
-
+    test("Test affy profile - affy_limma_gsea") {
 
         when {
             params {
-                outdir              = "$outputDir"
-                paramsheet          = "${projectDir}/conf/test_paramsheet.yaml"
-                paramset_name       = "limma_affy_gsea"
+                outdir                     = "$outputDir"
+
+                // Study info
+                study_name                 = 'GSE50790'
+
+                // Input data
+                input                      = 'https://raw.githubusercontent.com/nf-core/test-datasets/differentialabundance/testdata/GSE50790.csv'
+                contrasts_yml              = 'https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/differentialabundance/testdata/GSE50790_contrasts.yaml'
+                affy_cel_files_archive     = 'https://raw.githubusercontent.com/nf-core/test-datasets/differentialabundance/testdata/GSE50790_RAW.tar'
+                gene_sets_files            = 'https://raw.githubusercontent.com/nf-core/test-datasets/differentialabundance/testdata/h.all.v2022.1.Hs.symbols.gmt'
+
+                // Observations
+                observations_id_col        = 'name'
+                observations_name_col      = 'name'
+
+                // Exploratory
+                exploratory_main_variable  = 'contrasts'
+
+                // Differential analysis params
+                differential_max_pval      = 0.05
+                differential_max_qval      = 0.05
+                differential_min_fold_change = 1.5
+
+                // GSEA
+                gsea_rnd_seed              = '10'
             }
+            profile 'affy_limma_gsea'
         }
 
         then {
-            // stable_name: All files + folders in ${params.outdir}/ with a stable name
             def stable_name = getAllFilesFromDir(params.outdir, relative: true, includeDir: true, ignore: ['pipeline_info/*.{html,json,txt}',
                     'report/gsea/*/phenotype_uninvolved_lesional*/**/*.png'
             ])
-            // stable_path: All files in ${params.outdir}/ with stable content
             def stable_path = getAllFilesFromDir(params.outdir, ignoreFile: 'tests/.nftignore')
             assertAll(
                 { assert workflow.success},
                 { assert snapshot(
-                    // Number of successful tasks
                     workflow.trace.succeeded().size(),
-                    // pipeline versions.yml file for multiqc from which Nextflow version is removed because we tests pipelines on multiple Nextflow versions
                     removeNextflowVersion("$outputDir/pipeline_info/nf_core_differentialabundance_software_versions.yml"),
-                    // All stable path name, with a relative path
                     stable_name,
-                    // All files with stable contents
                     stable_path
                 ).match() }
-                )
+            )
         }
     }
 
-    test("Test affy profile - limma_affy_gsea,limma_affy_gprofiler2") {
+    test("Test affy profile - affy_limma_gprofiler2") {
 
         when {
             params {
-                outdir              = "$outputDir"
-                paramsheet          = "${projectDir}/conf/test_paramsheet.yaml"
-                paramset_name       = "limma_affy_gsea,limma_affy_gprofiler2"
+                outdir                     = "$outputDir"
+
+                // Study info
+                study_name                 = 'GSE50790'
+
+                // Input data
+                input                      = 'https://raw.githubusercontent.com/nf-core/test-datasets/differentialabundance/testdata/GSE50790.csv'
+                contrasts_yml              = 'https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/differentialabundance/testdata/GSE50790_contrasts.yaml'
+                affy_cel_files_archive     = 'https://raw.githubusercontent.com/nf-core/test-datasets/differentialabundance/testdata/GSE50790_RAW.tar'
+
+                // Observations
+                observations_id_col        = 'name'
+                observations_name_col      = 'name'
+
+                // Exploratory
+                exploratory_main_variable  = 'contrasts'
+
+                // Differential analysis params
+                differential_max_pval      = 0.05
+                differential_max_qval      = 0.05
+                differential_min_fold_change = 1.5
+
+                // gprofiler2 options
+                gprofiler2_organism        = 'mmusculus'
             }
+            profile 'affy_limma_gprofiler2'
         }
 
         then {
-            // stable_name: All files + folders in ${params.outdir}/ with a stable name
             def stable_name = getAllFilesFromDir(params.outdir, relative: true, includeDir: true, ignore: ['pipeline_info/*.{html,json,txt}',
                     'report/gsea/*/phenotype_uninvolved_lesional*/**/*.png'
             ])
-            // stable_path: All files in ${params.outdir}/ with stable content
             def stable_path = getAllFilesFromDir(params.outdir, ignoreFile: 'tests/.nftignore')
             assertAll(
                 { assert workflow.success},
                 { assert snapshot(
-                    // Number of successful tasks
                     workflow.trace.succeeded().size(),
-                    // pipeline versions.yml file for multiqc from which Nextflow version is removed because we tests pipelines on multiple Nextflow versions
                     removeNextflowVersion("$outputDir/pipeline_info/nf_core_differentialabundance_software_versions.yml"),
-                    // All stable path name, with a relative path
                     stable_name,
-                    // All files with stable contents
                     stable_path
                 ).match() }
-                )
+            )
         }
     }
 }

--- a/tests/test_maxquant.nf.test
+++ b/tests/test_maxquant.nf.test
@@ -5,36 +5,43 @@ nextflow_pipeline {
     tag "maxquant"
     tag "pipeline"
 
-
-    test("Test maxquant profile - limma_maxquant") {
+    test("Test maxquant profile - maxquant") {
 
         when {
             params {
-                outdir              = "$outputDir"
-                paramsheet          = "${projectDir}/conf/test_paramsheet.yaml"
-                paramset_name       = "limma_maxquant"
-            }
+                outdir                     = "$outputDir"
 
+                // Study info
+                study_name                 = 'PXD043349'
+
+                // Input data
+                input                      = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/proteomics/maxquant/MaxQuant_samplesheet.tsv'
+                matrix                     = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/proteomics/maxquant/MaxQuant_proteinGroups.txt'
+                contrasts_yml              = 'https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/differentialabundance/testdata/MaxQuant_contrasts.yaml'
+
+                // Observations
+                observations_id_col        = 'Experiment'
+                observations_name_col      = 'Name'
+
+                // Exploratory
+                exploratory_main_variable  = 'Celltype'
+                exploratory_n_features     = -1
+            }
+            profile 'maxquant'
         }
 
         then {
-            // stable_name: All files + folders in ${params.outdir}/ with a stable name
             def stable_name = getAllFilesFromDir(params.outdir, relative: true, includeDir: true, ignore: ['pipeline_info/*.{html,json,txt}'])
-            // stable_path: All files in ${params.outdir}/ with stable content
             def stable_path = getAllFilesFromDir(params.outdir, ignoreFile: 'tests/.nftignore')
             assertAll(
                 { assert workflow.success},
                 { assert snapshot(
-                    // Number of successful tasks
                     workflow.trace.succeeded().size(),
-                    // pipeline versions.yml file for multiqc from which Nextflow version is removed because we tests pipelines on multiple Nextflow versions
                     removeNextflowVersion("$outputDir/pipeline_info/nf_core_differentialabundance_software_versions.yml"),
-                    // All stable path name, with a relative path
                     stable_name,
-                    // All files with stable contents
                     stable_path
                 ).match() }
-                )
+            )
         }
     }
 }

--- a/tests/test_nogtf.nf.test
+++ b/tests/test_nogtf.nf.test
@@ -9,30 +9,38 @@ nextflow_pipeline {
 
         when {
             params {
-                outdir              = "$outputDir"
-                paramsheet          = "${projectDir}/conf/test_paramsheet.yaml"
-                paramset_name       = "rnaseq_nogtf"
+                outdir                     = "$outputDir"
+
+                // Study info
+                study_name                 = 'SRP254919'
+
+                // Input data
+                input                      = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.samplesheet.csv'
+                matrix                     = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.salmon.merged.gene_counts.top1000cov.tsv'
+                contrasts_yml              = 'https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/differentialabundance/testdata/SRP254919.contrasts.yaml'
+
+                // Exploratory plots
+                exploratory_main_variable  = 'contrasts'
+                deseq2_vst_nsub            = 500
+
+                // Filtering
+                filtering_min_abundance    = 10
             }
+            profile 'rnaseq_nogtf'
         }
 
         then {
-            // stable_name: All files + folders in ${params.outdir}/ with a stable name
             def stable_name = getAllFilesFromDir(params.outdir, relative: true, includeDir: true, ignore: ['pipeline_info/*.{html,json,txt}'])
-            // stable_path: All files in ${params.outdir}/ with stable content
             def stable_path = getAllFilesFromDir(params.outdir, ignoreFile: 'tests/.nftignore')
             assertAll(
                 { assert workflow.success},
                 { assert snapshot(
-                    // Number of successful tasks
                     workflow.trace.succeeded().size(),
-                    // pipeline versions.yml file for multiqc from which Nextflow version is removed because we tests pipelines on multiple Nextflow versions
                     removeNextflowVersion("$outputDir/pipeline_info/nf_core_differentialabundance_software_versions.yml"),
-                    // All stable path name, with a relative path
                     stable_name,
-                    // All files with stable contents
                     stable_path
                 ).match() }
-                )
+            )
         }
     }
 }

--- a/tests/test_rnaseq_deseq2.nf.test
+++ b/tests/test_rnaseq_deseq2.nf.test
@@ -5,95 +5,199 @@ nextflow_pipeline {
     tag "test_rnaseq_deseq2"
     tag "pipeline"
 
-    test("Test profile - deseq2_rnaseq_gsea") {
+    test("Test profile - rnaseq_deseq2_gsea") {
 
         when {
             params {
-                outdir        = "$outputDir"
-                paramsheet    = "${projectDir}/conf/test_paramsheet.yaml"
-                paramset_name = "deseq2_rnaseq_gsea"
+                outdir                     = "$outputDir"
+
+                // Study info
+                study_name                 = 'SRP254919'
+
+                // Input data
+                input                      = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.samplesheet.csv'
+                matrix                     = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.salmon.merged.gene_counts.top1000cov.tsv'
+                transcript_length_matrix   = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.spoofed_lengths.tsv'
+                contrasts_yml              = 'https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/differentialabundance/testdata/SRP254919.contrasts.yaml'
+                gtf                        = 'https://ftp.ensembl.org/pub/release-81/gtf/mus_musculus/Mus_musculus.GRCm38.81.gtf.gz'
+                gene_sets_files            = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/gene_set_analysis/mh.all.v2022.1.Mm.symbols.gmt'
+
+                // Exploratory plots
+                exploratory_main_variable  = 'contrasts'
+                deseq2_vst_nsub            = 500
+
+                // Filtering
+                filtering_min_abundance    = 10
+
+                // Report options
+                report_contributors        = 'Jane Doe\nDirector of Institute of Microbiology\nUniversity of Smallville;John Smith\nPhD student\nInstitute of Microbiology\nUniversity of Smallville'
+
+                // Other
+                round_digits               = 3
+                gsea_rnd_seed              = '10'
             }
+            profile 'rnaseq_deseq2_gsea'
         }
 
         then {
-            // stable_name: All files + folders in ${params.outdir}/ with a stable name
             def stable_name = getAllFilesFromDir(params.outdir, relative: true, includeDir: true, ignore: ['pipeline_info/*.{html,json,txt}'])
-            // stable_path: All files in ${params.outdir}/ with stable content
             def stable_path = getAllFilesFromDir(params.outdir, ignoreFile: 'tests/.nftignore')
             assertAll(
                 { assert workflow.success},
                 { assert snapshot(
-                    // Number of successful tasks
                     workflow.trace.succeeded().size(),
-                    // pipeline versions.yml file for multiqc from which Nextflow version is removed because we tests pipelines on multiple Nextflow versions
                     removeNextflowVersion("$outputDir/pipeline_info/nf_core_differentialabundance_software_versions.yml"),
-                    // All stable path name, with a relative path
                     stable_name,
-                    // All files with stable contents
                     stable_path
                 ).match() }
-                )
+            )
         }
     }
 
-    test("Test profile - deseq2_rnaseq_gsea,deseq2_rnaseq_gprofiler2") {
+    test("Test profile - rnaseq_deseq2_gprofiler2") {
 
         when {
             params {
-                outdir        = "$outputDir"
-                paramsheet    = "${projectDir}/conf/test_paramsheet.yaml"
-                paramset_name = "deseq2_rnaseq_gsea,deseq2_rnaseq_gprofiler2"
+                outdir                     = "$outputDir"
+
+                // Study info
+                study_name                 = 'SRP254919'
+
+                // Input data
+                input                      = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.samplesheet.csv'
+                matrix                     = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.salmon.merged.gene_counts.top1000cov.tsv'
+                transcript_length_matrix   = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.spoofed_lengths.tsv'
+                contrasts_yml              = 'https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/differentialabundance/testdata/SRP254919.contrasts.yaml'
+                gtf                        = 'https://ftp.ensembl.org/pub/release-81/gtf/mus_musculus/Mus_musculus.GRCm38.81.gtf.gz'
+
+                // Exploratory plots
+                exploratory_main_variable  = 'contrasts'
+                deseq2_vst_nsub            = 500
+
+                // Filtering
+                filtering_min_abundance    = 10
+
+                // gprofiler2 options
+                gprofiler2_organism        = 'mmusculus'
+
+                // Report options
+                report_contributors        = 'Jane Doe\nDirector of Institute of Microbiology\nUniversity of Smallville;John Smith\nPhD student\nInstitute of Microbiology\nUniversity of Smallville'
+
+                // Other
+                round_digits               = 3
             }
+            profile 'rnaseq_deseq2_gprofiler2'
         }
 
         then {
-            // stable_name: All files + folders in ${params.outdir}/ with a stable name
             def stable_name = getAllFilesFromDir(params.outdir, relative: true, includeDir: true, ignore: ['pipeline_info/*.{html,json,txt}'])
-            // stable_path: All files in ${params.outdir}/ with stable content
             def stable_path = getAllFilesFromDir(params.outdir, ignoreFile: 'tests/.nftignore')
             assertAll(
                 { assert workflow.success},
                 { assert snapshot(
-                    // Number of successful tasks
                     workflow.trace.succeeded().size(),
-                    // pipeline versions.yml file for multiqc from which Nextflow version is removed because we tests pipelines on multiple Nextflow versions
                     removeNextflowVersion("$outputDir/pipeline_info/nf_core_differentialabundance_software_versions.yml"),
-                    // All stable path name, with a relative path
                     stable_name,
-                    // All files with stable contents
                     stable_path
                 ).match() }
-                )
+            )
         }
     }
 
-    test("Test - Numeric sample IDs") {
+    test("Test - Numeric sample IDs - rnaseq_deseq2_gsea") {
         when {
             params {
-                outdir        = "$outputDir"
-                paramsheet    = "${projectDir}/conf/test_paramsheet.yaml"
-                paramset_name = "deseq2_rnaseq_gsea_numeric_samples,deseq2_rnaseq_gprofiler2_numeric_samples"
+                outdir                     = "$outputDir"
+
+                // Study info
+                study_name                 = 'SRP254919'
+
+                // Input data (local files with numeric sample IDs)
+                input                      = '${projectDir}/tests/assets/SRP254919.samplesheet.csv'
+                matrix                     = '${projectDir}/tests/assets/SRP254919.salmon.merged.gene_counts.top1000cov.tsv'
+                transcript_length_matrix   = '${projectDir}/tests/assets/SRP254919.spoofed_lengths.tsv'
+                contrasts_yml              = 'https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/differentialabundance/testdata/SRP254919.contrasts.yaml'
+                gtf                        = 'https://ftp.ensembl.org/pub/release-81/gtf/mus_musculus/Mus_musculus.GRCm38.81.gtf.gz'
+                gene_sets_files            = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/gene_set_analysis/mh.all.v2022.1.Mm.symbols.gmt'
+
+                // Exploratory plots
+                exploratory_main_variable  = 'contrasts'
+                deseq2_vst_nsub            = 500
+
+                // Filtering
+                filtering_min_abundance    = 10
+
+                // Report options
+                report_contributors        = 'Jane Doe\nDirector of Institute of Microbiology\nUniversity of Smallville;John Smith\nPhD student\nInstitute of Microbiology\nUniversity of Smallville'
+
+                // Other
+                round_digits               = 3
+                gsea_rnd_seed              = '10'
             }
+            profile 'rnaseq_deseq2_gsea'
         }
 
         then {
-            // stable_name: All files + folders in ${params.outdir}/ with a stable name
             def stable_name = getAllFilesFromDir(params.outdir, relative: true, includeDir: true, ignore: ['pipeline_info/*.{html,json,txt}'])
-            // stable_path: All files in ${params.outdir}/ with stable content
             def stable_path = getAllFilesFromDir(params.outdir, ignoreFile: 'tests/.nftignore')
             assertAll(
                 { assert workflow.success},
                 { assert snapshot(
-                    // Number of successful tasks
                     workflow.trace.succeeded().size(),
-                    // pipeline versions.yml file for multiqc from which Nextflow version is removed because we tests pipelines on multiple Nextflow versions
                     removeNextflowVersion("$outputDir/pipeline_info/nf_core_differentialabundance_software_versions.yml"),
-                    // All stable path name, with a relative path
                     stable_name,
-                    // All files with stable contents
                     stable_path
                 ).match() }
-                )
+            )
+        }
+    }
+
+    test("Test - Numeric sample IDs - rnaseq_deseq2_gprofiler2") {
+        when {
+            params {
+                outdir                     = "$outputDir"
+
+                // Study info
+                study_name                 = 'SRP254919'
+
+                // Input data (local files with numeric sample IDs)
+                input                      = '${projectDir}/tests/assets/SRP254919.samplesheet.csv'
+                matrix                     = '${projectDir}/tests/assets/SRP254919.salmon.merged.gene_counts.top1000cov.tsv'
+                transcript_length_matrix   = '${projectDir}/tests/assets/SRP254919.spoofed_lengths.tsv'
+                contrasts_yml              = 'https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/differentialabundance/testdata/SRP254919.contrasts.yaml'
+                gtf                        = 'https://ftp.ensembl.org/pub/release-81/gtf/mus_musculus/Mus_musculus.GRCm38.81.gtf.gz'
+
+                // Exploratory plots
+                exploratory_main_variable  = 'contrasts'
+                deseq2_vst_nsub            = 500
+
+                // Filtering
+                filtering_min_abundance    = 10
+
+                // gprofiler2 options
+                gprofiler2_organism        = 'mmusculus'
+
+                // Report options
+                report_contributors        = 'Jane Doe\nDirector of Institute of Microbiology\nUniversity of Smallville;John Smith\nPhD student\nInstitute of Microbiology\nUniversity of Smallville'
+
+                // Other
+                round_digits               = 3
+            }
+            profile 'rnaseq_deseq2_gprofiler2'
+        }
+
+        then {
+            def stable_name = getAllFilesFromDir(params.outdir, relative: true, includeDir: true, ignore: ['pipeline_info/*.{html,json,txt}'])
+            def stable_path = getAllFilesFromDir(params.outdir, ignoreFile: 'tests/.nftignore')
+            assertAll(
+                { assert workflow.success},
+                { assert snapshot(
+                    workflow.trace.succeeded().size(),
+                    removeNextflowVersion("$outputDir/pipeline_info/nf_core_differentialabundance_software_versions.yml"),
+                    stable_name,
+                    stable_path
+                ).match() }
+            )
         }
     }
 }

--- a/tests/test_rnaseq_dream.nf.test
+++ b/tests/test_rnaseq_dream.nf.test
@@ -36,12 +36,42 @@ nextflow_pipeline {
         }
     }
 
-    test("Test rnaseq dream profile - complex contrast - with zero intercept") {
+    test("Test rnaseq dream profile - complex contrast - with zero intercept - 1") {
         when {
             params {
                 outdir              = "$outputDir"
                 paramsheet          = "${projectDir}/conf/test_paramsheet.yaml"
                 paramset_name       = "dream_norm"
+            }
+        }
+
+        then {
+            // stable_name: All files + folders in ${params.outdir}/ with a stable name
+            def stable_name = getAllFilesFromDir(params.outdir, relative: true, includeDir: true, ignore: ['pipeline_info/*.{html,json,txt}'])
+            // stable_path: All files in ${params.outdir}/ with stable content
+            def stable_path = getAllFilesFromDir(params.outdir, ignoreFile: 'tests/.nftignore')
+            assertAll(
+                { assert workflow.success},
+                { assert snapshot(
+                    // Number of successful tasks
+                    workflow.trace.succeeded().size(),
+                    // pipeline versions.yml file for multiqc from which Nextflow version is removed because we tests pipelines on multiple Nextflow versions
+                    removeNextflowVersion("$outputDir/pipeline_info/nf_core_differentialabundance_software_versions.yml"),
+                    // All stable path name, with a relative path
+                    stable_name,
+                    // All files with stable contents
+                    stable_path
+                ).match() }
+                )
+        }
+    }
+
+    test("Test rnaseq dream profile - complex contrast - with zero intercept - 2") {
+        when {
+            params {
+                outdir              = "$outputDir"
+                paramsheet          = "${projectDir}/conf/test_paramsheet.yaml"
+                paramset_name       = "dream_norm2"
             }
         }
 

--- a/tests/test_rnaseq_dream.nf.test
+++ b/tests/test_rnaseq_dream.nf.test
@@ -5,155 +5,194 @@ nextflow_pipeline {
     tag "rnaseq_dream"
     tag "pipeline"
 
-    test("Test rnaseq dream profile - dream_rnaseq") {
+    test("Test rnaseq dream profile - rnaseq_dream") {
 
         when {
             params {
-                outdir              = "$outputDir"
-                paramsheet          = "${projectDir}/conf/test_paramsheet.yaml"
-                paramset_name       = "dream_rnaseq"
+                outdir                     = "$outputDir"
+
+                // Study info
+                study_name                 = 'SRP254919'
+
+                // Input data (complex dataset)
+                input                      = 'https://github.com/nf-core/test-datasets/raw/differentialabundance/modules_testdata/variancepartition_dream/metadata.tsv'
+                matrix                     = 'https://github.com/nf-core/test-datasets/raw/differentialabundance/modules_testdata/variancepartition_dream/counts.tsv'
+                contrasts_yml              = 'https://github.com/nf-core/test-datasets/raw/differentialabundance/testdata/formula_contrasts/rnaseq_complex_contrast.yaml'
+                gtf                        = 'https://ftp.ensembl.org/pub/release-81/gtf/mus_musculus/Mus_musculus.GRCm38.81.gtf.gz'
+
+                // DREAM settings
+                dream_apply_voom           = true
+
+                // Filtering
+                filtering_min_abundance    = 10
+
+                // Exploratory
+                exploratory_main_variable  = 'contrasts'
+
+                // Report options
+                report_contributors        = 'Jane Doe\nDirector of Institute of Microbiology\nUniversity of Smallville;John Smith\nPhD student\nInstitute of Microbiology\nUniversity of Smallville'
+
+                // Other
+                round_digits               = 3
             }
+            profile 'rnaseq_dream'
         }
 
         then {
-            // stable_name: All files + folders in ${params.outdir}/ with a stable name
             def stable_name = getAllFilesFromDir(params.outdir, relative: true, includeDir: true, ignore: ['pipeline_info/*.{html,json,txt}'])
-            // stable_path: All files in ${params.outdir}/ with stable content
             def stable_path = getAllFilesFromDir(params.outdir, ignoreFile: 'tests/.nftignore')
             assertAll(
                 { assert workflow.success},
                 { assert snapshot(
-                    // Number of successful tasks
                     workflow.trace.succeeded().size(),
-                    // pipeline versions.yml file for multiqc from which Nextflow version is removed because we tests pipelines on multiple Nextflow versions
                     removeNextflowVersion("$outputDir/pipeline_info/nf_core_differentialabundance_software_versions.yml"),
-                    // All stable path name, with a relative path
                     stable_name,
-                    // All files with stable contents
                     stable_path
                 ).match() }
-                )
+            )
         }
     }
 
-    test("Test rnaseq dream profile - complex contrast - with zero intercept - 1") {
+    test("Test rnaseq dream profile - complex contrast - with zero intercept") {
         when {
             params {
-                outdir              = "$outputDir"
-                paramsheet          = "${projectDir}/conf/test_paramsheet.yaml"
-                paramset_name       = "dream_norm"
+                outdir                     = "$outputDir"
+
+                // Study info
+                study_name                 = 'SRP254919'
+
+                // Input data (complex dataset with zero intercept contrasts)
+                input                      = 'https://github.com/nf-core/test-datasets/raw/differentialabundance/modules_testdata/variancepartition_dream/metadata.tsv'
+                matrix                     = 'https://github.com/nf-core/test-datasets/raw/differentialabundance/modules_testdata/variancepartition_dream/counts.tsv'
+                contrasts_yml              = '${projectDir}/tests/assets/zero_intercept_contrasts.yml'
+                gtf                        = 'https://ftp.ensembl.org/pub/release-81/gtf/mus_musculus/Mus_musculus.GRCm38.81.gtf.gz'
+
+                // DREAM settings - override for dream_norm
+                dream_apply_voom           = false
+
+                // Exploratory settings for dream_norm (no voom)
+                exploratory_assay_names    = 'raw'
+                exploratory_final_assay    = 'raw'
+                exploratory_log2_assays    = 'raw'
+
+                // Filtering
+                filtering_min_abundance    = 10
+
+                // Exploratory
+                exploratory_main_variable  = 'contrasts'
+
+                // Report options
+                report_contributors        = 'Jane Doe\nDirector of Institute of Microbiology\nUniversity of Smallville;John Smith\nPhD student\nInstitute of Microbiology\nUniversity of Smallville'
+
+                // Other
+                round_digits               = 3
             }
+            profile 'rnaseq_dream'
         }
 
         then {
-            // stable_name: All files + folders in ${params.outdir}/ with a stable name
             def stable_name = getAllFilesFromDir(params.outdir, relative: true, includeDir: true, ignore: ['pipeline_info/*.{html,json,txt}'])
-            // stable_path: All files in ${params.outdir}/ with stable content
             def stable_path = getAllFilesFromDir(params.outdir, ignoreFile: 'tests/.nftignore')
             assertAll(
                 { assert workflow.success},
                 { assert snapshot(
-                    // Number of successful tasks
                     workflow.trace.succeeded().size(),
-                    // pipeline versions.yml file for multiqc from which Nextflow version is removed because we tests pipelines on multiple Nextflow versions
                     removeNextflowVersion("$outputDir/pipeline_info/nf_core_differentialabundance_software_versions.yml"),
-                    // All stable path name, with a relative path
                     stable_name,
-                    // All files with stable contents
                     stable_path
                 ).match() }
-                )
+            )
         }
     }
 
-    test("Test rnaseq dream profile - complex contrast - with zero intercept - 2") {
+    test("Test rnaseq dream profile - rnaseq_dream_decoupler") {
+
         when {
             params {
-                outdir              = "$outputDir"
-                paramsheet          = "${projectDir}/conf/test_paramsheet.yaml"
-                paramset_name       = "dream_norm2"
+                outdir                     = "$outputDir"
+
+                // Study info
+                study_name                 = 'SRP254919'
+
+                // Input data (complex dataset)
+                input                      = 'https://github.com/nf-core/test-datasets/raw/differentialabundance/modules_testdata/variancepartition_dream/metadata.tsv'
+                matrix                     = 'https://github.com/nf-core/test-datasets/raw/differentialabundance/modules_testdata/variancepartition_dream/counts.tsv'
+                contrasts_yml              = 'https://github.com/nf-core/test-datasets/raw/differentialabundance/testdata/formula_contrasts/rnaseq_complex_contrast.yaml'
+                gtf                        = 'https://ftp.ensembl.org/pub/release-81/gtf/mus_musculus/Mus_musculus.GRCm38.81.gtf.gz'
+                decoupler_network          = 'https://github.com/nf-core/test-datasets/raw/differentialabundance/modules_testdata/progeny/mouse_network.tsv'
+
+                // Filtering
+                filtering_min_abundance    = 10
+
+                // Functional analysis with decoupler
+                decoupler_min_n            = 1
+
+                // Report options
+                report_contributors        = 'Jane Doe\nDirector of Institute of Microbiology\nUniversity of Smallville;John Smith\nPhD student\nInstitute of Microbiology\nUniversity of Smallville'
+
+                // Other
+                round_digits               = 3
             }
+            profile 'rnaseq_dream_decoupler'
         }
 
         then {
-            // stable_name: All files + folders in ${params.outdir}/ with a stable name
             def stable_name = getAllFilesFromDir(params.outdir, relative: true, includeDir: true, ignore: ['pipeline_info/*.{html,json,txt}'])
-            // stable_path: All files in ${params.outdir}/ with stable content
             def stable_path = getAllFilesFromDir(params.outdir, ignoreFile: 'tests/.nftignore')
             assertAll(
                 { assert workflow.success},
                 { assert snapshot(
-                    // Number of successful tasks
                     workflow.trace.succeeded().size(),
-                    // pipeline versions.yml file for multiqc from which Nextflow version is removed because we tests pipelines on multiple Nextflow versions
                     removeNextflowVersion("$outputDir/pipeline_info/nf_core_differentialabundance_software_versions.yml"),
-                    // All stable path name, with a relative path
                     stable_name,
-                    // All files with stable contents
                     stable_path
                 ).match() }
-                )
+            )
         }
     }
 
-    test("Test rnaseq dream profile - with decoupler") {
-
+    test("Test - Numeric sample IDs - rnaseq_dream_decoupler") {
         when {
             params {
-                outdir              = "$outputDir"
-                paramsheet          = "${projectDir}/conf/test_paramsheet.yaml"
-                paramset_name       = "dream_rnaseq_decoupler"
+                outdir                     = "$outputDir"
+
+                // Study info
+                study_name                 = 'SRP254919'
+
+                // Input data (local files with numeric sample IDs)
+                input                      = '${projectDir}/tests/assets/SRP254919.samplesheet.csv'
+                matrix                     = '${projectDir}/tests/assets/SRP254919.salmon.merged.gene_counts.top1000cov.tsv'
+                contrasts_yml              = '${projectDir}/tests/assets/SRP254919_dream.contrasts.yaml'
+                gtf                        = 'https://ftp.ensembl.org/pub/release-81/gtf/mus_musculus/Mus_musculus.GRCm38.81.gtf.gz'
+                decoupler_network          = 'https://github.com/nf-core/test-datasets/raw/differentialabundance/modules_testdata/progeny/mouse_network.tsv'
+
+                // Filtering
+                filtering_min_abundance    = 10
+
+                // Functional analysis with decoupler
+                decoupler_min_n            = 1
+
+                // Report options
+                report_contributors        = 'Jane Doe\nDirector of Institute of Microbiology\nUniversity of Smallville;John Smith\nPhD student\nInstitute of Microbiology\nUniversity of Smallville'
+
+                // Other
+                round_digits               = 3
             }
+            profile 'rnaseq_dream_decoupler'
         }
 
         then {
-            // stable_name: All files + folders in ${params.outdir}/ with a stable name
             def stable_name = getAllFilesFromDir(params.outdir, relative: true, includeDir: true, ignore: ['pipeline_info/*.{html,json,txt}'])
-            // stable_path: All files in ${params.outdir}/ with stable content
             def stable_path = getAllFilesFromDir(params.outdir, ignoreFile: 'tests/.nftignore')
             assertAll(
                 { assert workflow.success},
                 { assert snapshot(
-                    // Number of successful tasks
                     workflow.trace.succeeded().size(),
-                    // pipeline versions.yml file for multiqc from which Nextflow version is removed because we tests pipelines on multiple Nextflow versions
                     removeNextflowVersion("$outputDir/pipeline_info/nf_core_differentialabundance_software_versions.yml"),
-                    // All stable path name, with a relative path
                     stable_name,
-                    // All files with stable contents
                     stable_path
                 ).match() }
-                )
-        }
-    }
-
-    test("Test - Numeric sample IDs - rnaseq dream profile - with decoupler") {
-        when {
-            params {
-                outdir              = "$outputDir"
-                paramsheet          = "${projectDir}/conf/test_paramsheet.yaml"
-                paramset_name       = "dream_rnaseq_decoupler_numeric_samples"
-            }
-        }
-
-        then {
-            // stable_name: All files + folders in ${params.outdir}/ with a stable name
-            def stable_name = getAllFilesFromDir(params.outdir, relative: true, includeDir: true, ignore: ['pipeline_info/*.{html,json,txt}'])
-            // stable_path: All files in ${params.outdir}/ with stable content
-            def stable_path = getAllFilesFromDir(params.outdir, ignoreFile: 'tests/.nftignore')
-            assertAll(
-                { assert workflow.success},
-                { assert snapshot(
-                    // Number of successful tasks
-                    workflow.trace.succeeded().size(),
-                    // pipeline versions.yml file for multiqc from which Nextflow version is removed because we tests pipelines on multiple Nextflow versions
-                    removeNextflowVersion("$outputDir/pipeline_info/nf_core_differentialabundance_software_versions.yml"),
-                    // All stable path name, with a relative path
-                    stable_name,
-                    // All files with stable contents
-                    stable_path
-                ).match() }
-                )
+            )
         }
     }
 }

--- a/tests/test_rnaseq_dream.nf.test.snap
+++ b/tests/test_rnaseq_dream.nf.test.snap
@@ -1,4 +1,188 @@
 {
+    "Test rnaseq dream profile - complex contrast - with zero intercept - 2": {
+        "content": [
+            18,
+            {
+                "CSVTK_JOIN": {
+                    "csvtk": "0.31.0"
+                },
+                "CUSTOM_FILTERDIFFERENTIALTABLE": {
+                    "pandas": "1.5.2"
+                },
+                "GTF_TO_TABLE": {
+                    "atlas-gene-annotation-manipulation": "1.1.1"
+                },
+                "GUNZIP_GTF": {
+                    "gunzip": 1.13
+                },
+                "PLOT_DIFFERENTIAL": {
+                    "r-shinyngs": "2.3.0"
+                },
+                "VALIDATOR": {
+                    "r-shinyngs": "2.3.0"
+                },
+                "VARIANCEPARTITION_DREAM": {
+                    "r-base": "4.3.3",
+                    "bioconductor-edger": "4.0.16",
+                    "variancePartition": "1.32.2"
+                },
+                "Workflow": {
+                    "nf-core/differentialabundance": "v1.6.0dev"
+                }
+            },
+            [
+                "pipeline_info",
+                "pipeline_info/collated_versions.yml",
+                "pipeline_info/nf_core_differentialabundance_software_versions.yml",
+                "plots",
+                "plots/differential",
+                "plots/differential/dream_norm2",
+                "plots/differential/dream_norm2/full_model_with_interactions_SRP254919",
+                "plots/differential/dream_norm2/full_model_with_interactions_SRP254919/png",
+                "plots/differential/dream_norm2/full_model_with_interactions_SRP254919/png/volcano.png",
+                "plots/differential/dream_norm2/versions.yml",
+                "plots/differential/dream_norm2/zero_intercept_model_1_SRP254919",
+                "plots/differential/dream_norm2/zero_intercept_model_1_SRP254919/png",
+                "plots/differential/dream_norm2/zero_intercept_model_1_SRP254919/png/volcano.png",
+                "plots/differential/dream_norm2/zero_intercept_model_2_SRP254919",
+                "plots/differential/dream_norm2/zero_intercept_model_2_SRP254919/png",
+                "plots/differential/dream_norm2/zero_intercept_model_2_SRP254919/png/volcano.png",
+                "report",
+                "report/dream_norm2",
+                "report/dream_norm2/SRP254919.zip",
+                "report/dream_norm2/SRP254919_differentialabundance_report.html",
+                "tables",
+                "tables/annotation",
+                "tables/annotation/dream_norm2",
+                "tables/annotation/dream_norm2/SRP254919.anno.tsv",
+                "tables/differential",
+                "tables/differential/dream_norm2",
+                "tables/differential/dream_norm2/full_model_with_interactions_SRP254919.dream.results.tsv",
+                "tables/differential/dream_norm2/full_model_with_interactions_SRP254919.dream.results_filtered.tsv",
+                "tables/differential/dream_norm2/full_model_with_interactions_SRP254919_dream.annotated.tsv",
+                "tables/differential/dream_norm2/zero_intercept_model_1_SRP254919.dream.results.tsv",
+                "tables/differential/dream_norm2/zero_intercept_model_1_SRP254919.dream.results_filtered.tsv",
+                "tables/differential/dream_norm2/zero_intercept_model_1_SRP254919_dream.annotated.tsv",
+                "tables/differential/dream_norm2/zero_intercept_model_2_SRP254919.dream.results.tsv",
+                "tables/differential/dream_norm2/zero_intercept_model_2_SRP254919.dream.results_filtered.tsv",
+                "tables/differential/dream_norm2/zero_intercept_model_2_SRP254919_dream.annotated.tsv"
+            ],
+            [
+                "versions.yml:md5,6f272b823a1be20b80a81cc01b70e1ed",
+                "SRP254919.anno.tsv:md5,c1d7f21e64bd00f845ec6545c123a1fb"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.3"
+        },
+        "timestamp": "2026-02-10T19:01:06.455827422"
+    },
+    "Test rnaseq dream profile - complex contrast - with zero intercept - 1": {
+        "content": [
+            20,
+            {
+                "CSVTK_JOIN": {
+                    "csvtk": "0.31.0"
+                },
+                "CUSTOM_FILTERDIFFERENTIALTABLE": {
+                    "pandas": "1.5.2"
+                },
+                "GTF_TO_TABLE": {
+                    "atlas-gene-annotation-manipulation": "1.1.1"
+                },
+                "GUNZIP_GTF": {
+                    "gunzip": 1.13
+                },
+                "PLOT_DIFFERENTIAL": {
+                    "r-shinyngs": "2.3.0"
+                },
+                "PLOT_EXPLORATORY": {
+                    "r-shinyngs": "2.3.0"
+                },
+                "SHINYNGS_APP": {
+                    "r-shinyngs": "2.3.0"
+                },
+                "VALIDATOR": {
+                    "r-shinyngs": "2.3.0"
+                },
+                "VARIANCEPARTITION_DREAM": {
+                    "r-base": "4.3.3",
+                    "bioconductor-edger": "4.0.16",
+                    "variancePartition": "1.32.2"
+                },
+                "Workflow": {
+                    "nf-core/differentialabundance": "v1.6.0dev"
+                }
+            },
+            [
+                "pipeline_info",
+                "pipeline_info/collated_versions.yml",
+                "pipeline_info/nf_core_differentialabundance_software_versions.yml",
+                "plots",
+                "plots/differential",
+                "plots/differential/dream_norm",
+                "plots/differential/dream_norm/interaction_genotype_treatment_SRP254919",
+                "plots/differential/dream_norm/interaction_genotype_treatment_SRP254919/png",
+                "plots/differential/dream_norm/interaction_genotype_treatment_SRP254919/png/volcano.png",
+                "plots/differential/dream_norm/treatment_effect_classic_comparison_SRP254919",
+                "plots/differential/dream_norm/treatment_effect_classic_comparison_SRP254919/png",
+                "plots/differential/dream_norm/treatment_effect_classic_comparison_SRP254919/png/volcano.png",
+                "plots/differential/dream_norm/treatment_plus_genotype_SRP254919",
+                "plots/differential/dream_norm/treatment_plus_genotype_SRP254919/png",
+                "plots/differential/dream_norm/treatment_plus_genotype_SRP254919/png/volcano.png",
+                "plots/differential/dream_norm/versions.yml",
+                "plots/exploratory",
+                "plots/exploratory/dream_norm",
+                "plots/exploratory/dream_norm/treatment",
+                "plots/exploratory/dream_norm/treatment/png",
+                "plots/exploratory/dream_norm/treatment/png/boxplot.png",
+                "plots/exploratory/dream_norm/treatment/png/density.png",
+                "plots/exploratory/dream_norm/treatment/png/mad_correlation.png",
+                "plots/exploratory/dream_norm/treatment/png/pca2d.png",
+                "plots/exploratory/dream_norm/treatment/png/pca3d.png",
+                "plots/exploratory/dream_norm/treatment/png/sample_dendrogram.png",
+                "plots/exploratory/dream_norm/versions.yml",
+                "report",
+                "report/dream_norm",
+                "report/dream_norm/SRP254919.zip",
+                "report/dream_norm/SRP254919_differentialabundance_report.html",
+                "shinyngs_app",
+                "shinyngs_app/dream_norm",
+                "shinyngs_app/dream_norm/SRP254919",
+                "shinyngs_app/dream_norm/SRP254919/app.R",
+                "shinyngs_app/dream_norm/SRP254919/data.rds",
+                "shinyngs_app/dream_norm/versions.yml",
+                "tables",
+                "tables/annotation",
+                "tables/annotation/dream_norm",
+                "tables/annotation/dream_norm/SRP254919.anno.tsv",
+                "tables/differential",
+                "tables/differential/dream_norm",
+                "tables/differential/dream_norm/interaction_genotype_treatment_SRP254919.dream.results.tsv",
+                "tables/differential/dream_norm/interaction_genotype_treatment_SRP254919.dream.results_filtered.tsv",
+                "tables/differential/dream_norm/interaction_genotype_treatment_SRP254919_dream.annotated.tsv",
+                "tables/differential/dream_norm/treatment_effect_classic_comparison_SRP254919.dream.results.tsv",
+                "tables/differential/dream_norm/treatment_effect_classic_comparison_SRP254919.dream.results_filtered.tsv",
+                "tables/differential/dream_norm/treatment_effect_classic_comparison_SRP254919_dream.annotated.tsv",
+                "tables/differential/dream_norm/treatment_plus_genotype_SRP254919.dream.results.tsv",
+                "tables/differential/dream_norm/treatment_plus_genotype_SRP254919.dream.results_filtered.tsv",
+                "tables/differential/dream_norm/treatment_plus_genotype_SRP254919_dream.annotated.tsv"
+            ],
+            [
+                "versions.yml:md5,6f272b823a1be20b80a81cc01b70e1ed",
+                "versions.yml:md5,d5db8686bec50d4d783d486fc4c0899a",
+                "app.R:md5,bedcfc45b6cdcc2b8fe3627987e2b17a",
+                "versions.yml:md5,ecfaf8bd98d719aecbb445e61e36c800",
+                "SRP254919.anno.tsv:md5,c1d7f21e64bd00f845ec6545c123a1fb"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.3"
+        },
+        "timestamp": "2026-02-10T18:57:47.37908848"
+    },
     "Test - Numeric sample IDs - rnaseq dream profile - with decoupler": {
         "content": [
             19,
@@ -391,128 +575,5 @@
             "nextflow": "25.04.2"
         },
         "timestamp": "2026-01-20T19:28:50.877373953"
-    },
-    "Test rnaseq dream profile - complex contrast - with zero intercept": {
-        "content": [
-            32,
-            {
-                "CSVTK_JOIN": {
-                    "csvtk": "0.31.0"
-                },
-                "CUSTOM_FILTERDIFFERENTIALTABLE": {
-                    "pandas": "1.5.2"
-                },
-                "GTF_TO_TABLE": {
-                    "atlas-gene-annotation-manipulation": "1.1.1"
-                },
-                "GUNZIP_GTF": {
-                    "gunzip": 1.13
-                },
-                "PLOT_DIFFERENTIAL": {
-                    "r-shinyngs": "2.3.0"
-                },
-                "PLOT_EXPLORATORY": {
-                    "r-shinyngs": "2.3.0"
-                },
-                "SHINYNGS_APP": {
-                    "r-shinyngs": "2.3.0"
-                },
-                "VALIDATOR": {
-                    "r-shinyngs": "2.3.0"
-                },
-                "VARIANCEPARTITION_DREAM": {
-                    "r-base": "4.3.3",
-                    "bioconductor-edger": "4.0.16",
-                    "variancePartition": "1.32.2"
-                },
-                "Workflow": {
-                    "nf-core/differentialabundance": "v1.6.0dev"
-                }
-            },
-            [
-                "pipeline_info",
-                "pipeline_info/collated_versions.yml",
-                "pipeline_info/nf_core_differentialabundance_software_versions.yml",
-                "plots",
-                "plots/differential",
-                "plots/differential/dream_norm",
-                "plots/differential/dream_norm/full_model_with_interactions_SRP254919",
-                "plots/differential/dream_norm/full_model_with_interactions_SRP254919/png",
-                "plots/differential/dream_norm/full_model_with_interactions_SRP254919/png/volcano.png",
-                "plots/differential/dream_norm/interaction_genotype_treatment_SRP254919",
-                "plots/differential/dream_norm/interaction_genotype_treatment_SRP254919/png",
-                "plots/differential/dream_norm/interaction_genotype_treatment_SRP254919/png/volcano.png",
-                "plots/differential/dream_norm/treatment_effect_classic_comparison_SRP254919",
-                "plots/differential/dream_norm/treatment_effect_classic_comparison_SRP254919/png",
-                "plots/differential/dream_norm/treatment_effect_classic_comparison_SRP254919/png/volcano.png",
-                "plots/differential/dream_norm/treatment_plus_genotype_SRP254919",
-                "plots/differential/dream_norm/treatment_plus_genotype_SRP254919/png",
-                "plots/differential/dream_norm/treatment_plus_genotype_SRP254919/png/volcano.png",
-                "plots/differential/dream_norm/versions.yml",
-                "plots/differential/dream_norm/zero_intercept_model_1_SRP254919",
-                "plots/differential/dream_norm/zero_intercept_model_1_SRP254919/png",
-                "plots/differential/dream_norm/zero_intercept_model_1_SRP254919/png/volcano.png",
-                "plots/differential/dream_norm/zero_intercept_model_2_SRP254919",
-                "plots/differential/dream_norm/zero_intercept_model_2_SRP254919/png",
-                "plots/differential/dream_norm/zero_intercept_model_2_SRP254919/png/volcano.png",
-                "plots/exploratory",
-                "plots/exploratory/dream_norm",
-                "plots/exploratory/dream_norm/treatment",
-                "plots/exploratory/dream_norm/treatment/png",
-                "plots/exploratory/dream_norm/treatment/png/boxplot.png",
-                "plots/exploratory/dream_norm/treatment/png/density.png",
-                "plots/exploratory/dream_norm/treatment/png/mad_correlation.png",
-                "plots/exploratory/dream_norm/treatment/png/pca2d.png",
-                "plots/exploratory/dream_norm/treatment/png/pca3d.png",
-                "plots/exploratory/dream_norm/treatment/png/sample_dendrogram.png",
-                "plots/exploratory/dream_norm/versions.yml",
-                "report",
-                "report/dream_norm",
-                "report/dream_norm/SRP254919.zip",
-                "report/dream_norm/SRP254919_differentialabundance_report.html",
-                "shinyngs_app",
-                "shinyngs_app/dream_norm",
-                "shinyngs_app/dream_norm/SRP254919",
-                "shinyngs_app/dream_norm/SRP254919/app.R",
-                "shinyngs_app/dream_norm/SRP254919/data.rds",
-                "shinyngs_app/dream_norm/versions.yml",
-                "tables",
-                "tables/annotation",
-                "tables/annotation/dream_norm",
-                "tables/annotation/dream_norm/SRP254919.anno.tsv",
-                "tables/differential",
-                "tables/differential/dream_norm",
-                "tables/differential/dream_norm/full_model_with_interactions_SRP254919.dream.results.tsv",
-                "tables/differential/dream_norm/full_model_with_interactions_SRP254919.dream.results_filtered.tsv",
-                "tables/differential/dream_norm/full_model_with_interactions_SRP254919_dream.annotated.tsv",
-                "tables/differential/dream_norm/interaction_genotype_treatment_SRP254919.dream.results.tsv",
-                "tables/differential/dream_norm/interaction_genotype_treatment_SRP254919.dream.results_filtered.tsv",
-                "tables/differential/dream_norm/interaction_genotype_treatment_SRP254919_dream.annotated.tsv",
-                "tables/differential/dream_norm/treatment_effect_classic_comparison_SRP254919.dream.results.tsv",
-                "tables/differential/dream_norm/treatment_effect_classic_comparison_SRP254919.dream.results_filtered.tsv",
-                "tables/differential/dream_norm/treatment_effect_classic_comparison_SRP254919_dream.annotated.tsv",
-                "tables/differential/dream_norm/treatment_plus_genotype_SRP254919.dream.results.tsv",
-                "tables/differential/dream_norm/treatment_plus_genotype_SRP254919.dream.results_filtered.tsv",
-                "tables/differential/dream_norm/treatment_plus_genotype_SRP254919_dream.annotated.tsv",
-                "tables/differential/dream_norm/zero_intercept_model_1_SRP254919.dream.results.tsv",
-                "tables/differential/dream_norm/zero_intercept_model_1_SRP254919.dream.results_filtered.tsv",
-                "tables/differential/dream_norm/zero_intercept_model_1_SRP254919_dream.annotated.tsv",
-                "tables/differential/dream_norm/zero_intercept_model_2_SRP254919.dream.results.tsv",
-                "tables/differential/dream_norm/zero_intercept_model_2_SRP254919.dream.results_filtered.tsv",
-                "tables/differential/dream_norm/zero_intercept_model_2_SRP254919_dream.annotated.tsv"
-            ],
-            [
-                "versions.yml:md5,6f272b823a1be20b80a81cc01b70e1ed",
-                "versions.yml:md5,d5db8686bec50d4d783d486fc4c0899a",
-                "app.R:md5,bedcfc45b6cdcc2b8fe3627987e2b17a",
-                "versions.yml:md5,ecfaf8bd98d719aecbb445e61e36c800",
-                "SRP254919.anno.tsv:md5,c1d7f21e64bd00f845ec6545c123a1fb"
-            ]
-        ],
-        "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.04.2"
-        },
-        "timestamp": "2026-01-22T14:06:46.658555468"
     }
 }

--- a/tests/test_rnaseq_limma.nf.test
+++ b/tests/test_rnaseq_limma.nf.test
@@ -5,159 +5,245 @@ nextflow_pipeline {
     tag "rnaseq_limma"
     tag "pipeline"
 
-    test("Test rnaseq limma profile - limma_rnaseq_gsea") {
+    test("Test rnaseq limma profile - rnaseq_limma_gsea") {
 
         when {
             params {
-                outdir        = "$outputDir"
-                paramsheet    = "${projectDir}/conf/test_paramsheet.yaml"
-                paramset_name = "limma_rnaseq_gsea"
+                outdir                     = "$outputDir"
+
+                // Study info
+                study_name                 = 'SRP254919'
+
+                // Input data
+                input                      = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.samplesheet.csv'
+                matrix                     = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.salmon.merged.gene_counts.top1000cov.tsv'
+                transcript_length_matrix   = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.spoofed_lengths.tsv'
+                contrasts_yml              = 'https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/differentialabundance/testdata/SRP254919.contrasts.yaml'
+                gtf                        = 'https://ftp.ensembl.org/pub/release-81/gtf/mus_musculus/Mus_musculus.GRCm38.81.gtf.gz'
+                gene_sets_files            = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/gene_set_analysis/mh.all.v2022.1.Mm.symbols.gmt'
+
+                // Filtering
+                filtering_min_abundance    = 10
+
+                // Exploratory
+                exploratory_main_variable  = 'contrasts'
+
+                // GSEA
+                gsea_rnd_seed              = '10'
+
+                // Report options
+                report_contributors        = 'Jane Doe\nDirector of Institute of Microbiology\nUniversity of Smallville;John Smith\nPhD student\nInstitute of Microbiology\nUniversity of Smallville'
+
+                // Other
+                round_digits               = 3
             }
+            profile 'rnaseq_limma_gsea'
         }
 
         then {
-            // stable_name: All files + folders in ${params.outdir}/ with a stable name
             def stable_name = getAllFilesFromDir(params.outdir, relative: true, includeDir: true, ignore: ['pipeline_info/*.{html,json,txt}'])
-            // stable_path: All files in ${params.outdir}/ with stable content
             def stable_path = getAllFilesFromDir(params.outdir, ignoreFile: 'tests/.nftignore')
             assertAll(
                 { assert workflow.success},
                 { assert snapshot(
-                    // Number of successful tasks
                     workflow.trace.succeeded().size(),
-                    // pipeline versions.yml file for multiqc from which Nextflow version is removed because we tests pipelines on multiple Nextflow versions
                     removeNextflowVersion("$outputDir/pipeline_info/nf_core_differentialabundance_software_versions.yml"),
-                    // All stable path name, with a relative path
                     stable_name,
-                    // All files with stable contents
                     stable_path
                 ).match() }
-                )
+            )
         }
     }
 
-    test("Test rnaseq limma profile - limma_rnaseq_gsea,limma_rnaseq_gprofiler2") {
+    test("Test rnaseq limma profile - rnaseq_limma_gprofiler2") {
 
         when {
             params {
-                outdir        = "$outputDir"
-                paramsheet    = "${projectDir}/conf/test_paramsheet.yaml"
-                paramset_name = "limma_rnaseq_gsea,limma_rnaseq_gprofiler2"
+                outdir                     = "$outputDir"
+
+                // Study info
+                study_name                 = 'SRP254919'
+
+                // Input data
+                input                      = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.samplesheet.csv'
+                matrix                     = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.salmon.merged.gene_counts.top1000cov.tsv'
+                transcript_length_matrix   = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.spoofed_lengths.tsv'
+                contrasts_yml              = 'https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/differentialabundance/testdata/SRP254919.contrasts.yaml'
+                gtf                        = 'https://ftp.ensembl.org/pub/release-81/gtf/mus_musculus/Mus_musculus.GRCm38.81.gtf.gz'
+
+                // Filtering
+                filtering_min_abundance    = 10
+
+                // gprofiler2 options
+                gprofiler2_organism        = 'mmusculus'
+
+                // Report options
+                report_contributors        = 'Jane Doe\nDirector of Institute of Microbiology\nUniversity of Smallville;John Smith\nPhD student\nInstitute of Microbiology\nUniversity of Smallville'
+
+                // Other
+                round_digits               = 3
             }
+            profile 'rnaseq_limma_gprofiler2'
         }
 
         then {
-            // stable_name: All files + folders in ${params.outdir}/ with a stable name
             def stable_name = getAllFilesFromDir(params.outdir, relative: true, includeDir: true, ignore: ['pipeline_info/*.{html,json,txt}'])
-            // stable_path: All files in ${params.outdir}/ with stable content
             def stable_path = getAllFilesFromDir(params.outdir, ignoreFile: 'tests/.nftignore')
             assertAll(
                 { assert workflow.success},
                 { assert snapshot(
-                    // Number of successful tasks
                     workflow.trace.succeeded().size(),
-                    // pipeline versions.yml file for multiqc from which Nextflow version is removed because we tests pipelines on multiple Nextflow versions
                     removeNextflowVersion("$outputDir/pipeline_info/nf_core_differentialabundance_software_versions.yml"),
-                    // All stable path name, with a relative path
                     stable_name,
-                    // All files with stable contents
                     stable_path
                 ).match() }
-                )
+            )
         }
     }
 
-    test("Test rnaseq limma profile - limma_rnaseq_gsea - with formula and complex contrasts") {
+    test("Test rnaseq limma profile - rnaseq_limma_gsea - with formula and complex contrasts") {
         tag "limma_rnaseq_gsea_complex"
 
         when {
             params {
-                outdir        = "$outputDir"
-                paramsheet    = "${projectDir}/conf/test_paramsheet.yaml"
-                paramset_name = "limma_rnaseq_gsea_complex"
+                outdir                     = "$outputDir"
+
+                // Study info
+                study_name                 = 'SRP254919'
+
+                // Input data (complex dataset)
+                input                      = 'https://github.com/nf-core/test-datasets/raw/differentialabundance/modules_testdata/variancepartition_dream/metadata.tsv'
+                matrix                     = 'https://github.com/nf-core/test-datasets/raw/differentialabundance/modules_testdata/variancepartition_dream/counts.tsv'
+                contrasts_yml              = 'https://github.com/nf-core/test-datasets/raw/differentialabundance/testdata/formula_contrasts/rnaseq_complex_contrast.yaml'
+                gtf                        = 'https://ftp.ensembl.org/pub/release-81/gtf/mus_musculus/Mus_musculus.GRCm38.81.gtf.gz'
+                gene_sets_files            = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/gene_set_analysis/mh.all.v2022.1.Mm.symbols.gmt'
+
+                // Filtering
+                filtering_min_abundance    = 10
+
+                // Exploratory
+                exploratory_main_variable  = 'contrasts'
+                exploratory_log2_assays    = 'raw'
+
+                // GSEA
+                gsea_rnd_seed              = '10'
+
+                // Report options
+                report_contributors        = 'Jane Doe\nDirector of Institute of Microbiology\nUniversity of Smallville;John Smith\nPhD student\nInstitute of Microbiology\nUniversity of Smallville'
+                report_grouping_variable   = 'treatment'
+
+                // Other
+                round_digits               = 3
             }
+            profile 'rnaseq_limma_gsea'
         }
 
         then {
-            // stable_name: All files + folders in ${params.outdir}/ with a stable name
             def stable_name = getAllFilesFromDir(params.outdir, relative: true, includeDir: true, ignore: ['pipeline_info/*.{html,json,txt}'])
-            // stable_path: All files in ${params.outdir}/ with stable content
             def stable_path = getAllFilesFromDir(params.outdir, ignoreFile: 'tests/.nftignore')
             assertAll(
                 { assert workflow.success},
                 { assert snapshot(
-                    // Number of successful tasks
                     workflow.trace.succeeded().size(),
-                    // pipeline versions.yml file for multiqc from which Nextflow version is removed because we tests pipelines on multiple Nextflow versions
                     removeNextflowVersion("$outputDir/pipeline_info/nf_core_differentialabundance_software_versions.yml"),
-                    // All stable path name, with a relative path
                     stable_name,
-                    // All files with stable contents
                     stable_path
                 ).match() }
-                )
+            )
         }
     }
 
-    test("Test rnaseq limma profile - with decoupler") {
+    test("Test rnaseq limma profile - rnaseq_limma_decoupler") {
         tag "limma_rnaseq_decoupler"
 
         when {
             params {
-                outdir        = "$outputDir"
-                paramsheet    = "${projectDir}/conf/test_paramsheet.yaml"
-                paramset_name = "limma_rnaseq_decoupler"
+                outdir                     = "$outputDir"
+
+                // Study info
+                study_name                 = 'SRP254919'
+
+                // Input data
+                input                      = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.samplesheet.csv'
+                matrix                     = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.salmon.merged.gene_counts.top1000cov.tsv'
+                transcript_length_matrix   = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.spoofed_lengths.tsv'
+                contrasts_yml              = 'https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/differentialabundance/testdata/SRP254919.contrasts.yaml'
+                gtf                        = 'https://ftp.ensembl.org/pub/release-81/gtf/mus_musculus/Mus_musculus.GRCm38.81.gtf.gz'
+                decoupler_network          = 'https://github.com/nf-core/test-datasets/raw/differentialabundance/modules_testdata/progeny/mouse_network.tsv'
+
+                // Filtering
+                filtering_min_abundance    = 10
+
+                // Report options
+                report_contributors        = 'Jane Doe\nDirector of Institute of Microbiology\nUniversity of Smallville;John Smith\nPhD student\nInstitute of Microbiology\nUniversity of Smallville'
+
+                // Other
+                round_digits               = 3
             }
+            profile 'rnaseq_limma_decoupler'
         }
 
         then {
-            // stable_name: All files + folders in ${params.outdir}/ with a stable name
             def stable_name = getAllFilesFromDir(params.outdir, relative: true, includeDir: true, ignore: ['pipeline_info/*.{html,json,txt}'])
-            // stable_path: All files in ${params.outdir}/ with stable content
             def stable_path = getAllFilesFromDir(params.outdir, ignoreFile: 'tests/.nftignore')
             assertAll(
                 { assert workflow.success},
                 { assert snapshot(
-                    // Number of successful tasks
                     workflow.trace.succeeded().size(),
-                    // pipeline versions.yml file for multiqc from which Nextflow version is removed because we tests pipelines on multiple Nextflow versions
                     removeNextflowVersion("$outputDir/pipeline_info/nf_core_differentialabundance_software_versions.yml"),
-                    // All stable path name, with a relative path
                     stable_name,
-                    // All files with stable contents
                     stable_path
                 ).match() }
-                )
+            )
         }
     }
 
-    test("Test rnaseq limma profile - limma_rnaseq_gsea - Numeric sample IDs") {
+    test("Test rnaseq limma profile - rnaseq_limma_gsea - Numeric sample IDs") {
         when {
             params {
-                outdir        = "$outputDir"
-                paramsheet    = "${projectDir}/conf/test_paramsheet.yaml"
-                paramset_name = "limma_rnaseq_gsea_numeric_samples"
+                outdir                     = "$outputDir"
+
+                // Study info
+                study_name                 = 'SRP254919'
+
+                // Input data (local files with numeric sample IDs)
+                input                      = '${projectDir}/tests/assets/SRP254919.samplesheet.csv'
+                matrix                     = '${projectDir}/tests/assets/SRP254919.salmon.merged.gene_counts.top1000cov.tsv'
+                transcript_length_matrix   = '${projectDir}/tests/assets/SRP254919.spoofed_lengths.tsv'
+                contrasts_yml              = 'https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/differentialabundance/testdata/SRP254919.contrasts.yaml'
+                gtf                        = 'https://ftp.ensembl.org/pub/release-81/gtf/mus_musculus/Mus_musculus.GRCm38.81.gtf.gz'
+                gene_sets_files            = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/gene_set_analysis/mh.all.v2022.1.Mm.symbols.gmt'
+
+                // Filtering
+                filtering_min_abundance    = 10
+
+                // Exploratory
+                exploratory_main_variable  = 'contrasts'
+
+                // GSEA
+                gsea_rnd_seed              = '10'
+
+                // Report options
+                report_contributors        = 'Jane Doe\nDirector of Institute of Microbiology\nUniversity of Smallville;John Smith\nPhD student\nInstitute of Microbiology\nUniversity of Smallville'
+
+                // Other
+                round_digits               = 3
             }
+            profile 'rnaseq_limma_gsea'
         }
 
         then {
-            // stable_name: All files + folders in ${params.outdir}/ with a stable name
             def stable_name = getAllFilesFromDir(params.outdir, relative: true, includeDir: true, ignore: ['pipeline_info/*.{html,json,txt}'])
-            // stable_path: All files in ${params.outdir}/ with stable content
             def stable_path = getAllFilesFromDir(params.outdir, ignoreFile: 'tests/.nftignore')
             assertAll(
                 { assert workflow.success},
                 { assert snapshot(
-                    // Number of successful tasks
                     workflow.trace.succeeded().size(),
-                    // pipeline versions.yml file for multiqc from which Nextflow version is removed because we tests pipelines on multiple Nextflow versions
                     removeNextflowVersion("$outputDir/pipeline_info/nf_core_differentialabundance_software_versions.yml"),
-                    // All stable path name, with a relative path
                     stable_name,
-                    // All files with stable contents
                     stable_path
                 ).match() }
-                )
+            )
         }
     }
 }

--- a/tests/test_soft.nf.test
+++ b/tests/test_soft.nf.test
@@ -5,35 +5,32 @@ nextflow_pipeline {
     tag "soft"
     tag "pipeline"
 
-
-    test("Test soft profile - limma_soft") {
+    test("Test soft profile - soft") {
 
         when {
             params {
-                outdir        = "$outputDir"
-                paramsheet    = "${projectDir}/conf/test_paramsheet.yaml"
-                paramset_name = "limma_soft"
+                outdir                     = "$outputDir"
+
+                // Input data
+                input                      = 'https://raw.githubusercontent.com/nf-core/test-datasets/differentialabundance/testdata/GSE50790.csv'
+                contrasts_yml              = 'https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/differentialabundance/testdata/GSE50790_contrasts.yaml'
+                querygse                   = 'GSE50790'
             }
+            profile 'soft'
         }
 
         then {
-            // stable_name: All files + folders in ${params.outdir}/ with a stable name
             def stable_name = getAllFilesFromDir(params.outdir, relative: true, includeDir: true, ignore: ['pipeline_info/*.{html,json,txt}'])
-            // stable_path: All files in ${params.outdir}/ with stable content
             def stable_path = getAllFilesFromDir(params.outdir, ignoreFile: 'tests/.nftignore')
             assertAll(
                 { assert workflow.success},
                 { assert snapshot(
-                    // Number of successful tasks
                     workflow.trace.succeeded().size(),
-                    // pipeline versions.yml file for multiqc from which Nextflow version is removed because we tests pipelines on multiple Nextflow versions
                     removeNextflowVersion("$outputDir/pipeline_info/nf_core_differentialabundance_software_versions.yml"),
-                    // All stable path name, with a relative path
                     stable_name,
-                    // All files with stable contents
                     stable_path
                 ).match() }
-                )
+            )
         }
     }
 }

--- a/workflows/differentialabundance.nf
+++ b/workflows/differentialabundance.nf
@@ -95,7 +95,7 @@ workflow DIFFERENTIALABUNDANCE {
     // Create optional parameter channels based on ch_paramsets
     ch_transcript_lengths = ch_paramsets
         .map { meta ->
-            [ meta, meta.params.transcript_length_matrix ? file(meta.params.transcript_length_matrix, checkIfExists: true) : [] ]
+            [ meta, meta.params.feature_length_matrix ? file(meta.params.feature_length_matrix, checkIfExists: true) : [] ]
         }
 
     ch_control_features = ch_paramsets


### PR DESCRIPTION
## Summary

This PR converts all pipeline tests from paramsheet-based to profile-based configuration, as part of the dual-mode architecture implementation for issue #472.

Builds on commit `a30eb88` which introduced the profile configs.

## Changes

### Tests Updated

| Test File | Profile(s) Used |
|-----------|-----------------|
| `default.nf.test` | `rnaseq_deseq2_gprofiler2` (for 'with formula' test) |
| `test_affy.nf.test` | `affy_limma_gsea`, `affy_limma_gprofiler2` |
| `test_maxquant.nf.test` | `maxquant` |
| `test_nogtf.nf.test` | `rnaseq_nogtf` |
| `test_rnaseq_deseq2.nf.test` | `rnaseq_deseq2_gsea`, `rnaseq_deseq2_gprofiler2` |
| `test_rnaseq_dream.nf.test` | `rnaseq_dream`, `rnaseq_dream_decoupler` |
| `test_rnaseq_limma.nf.test` | `rnaseq_limma_gsea`, `rnaseq_limma_gprofiler2`, `rnaseq_limma_decoupler` |
| `test_soft.nf.test` | `soft` |

### Key Changes
- Tests now use `profile '<profile_name>'` instead of `paramsheet` + `paramset_name`
- Input data URLs defined directly in test files (previously in testdata.yaml)
- Combined profile tests (e.g. `gsea,gprofiler2`) split into separate single-profile tests
- Numeric sample IDs tests split into separate tests per profile
- `test_many.nf.test` unchanged (intentional)

## Notes
- Snapshots will need updating after tests pass

---
*— Luna (AI assistant for @suzannejin)*